### PR TITLE
Better loop choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ with high compression ratio and moderately fast speed.
 
 It is also possible to implement your own data type via `NumberLike` and (if
 necessary) `UnsignedLike` and `FloatLike`.
-For smaller integers or timestamps, it is best to simply case to one of the
+For smaller integers or timestamps, it is best to simply cast to one of the
 natively supported data types.
 
 ## Get Started

--- a/bench/src/codecs/pco.rs
+++ b/bench/src/codecs/pco.rs
@@ -15,7 +15,11 @@ impl CodecInternal for PcoConfig {
   fn get_conf(&self, key: &str) -> String {
     match key {
       "level" => self.compressor_config.compression_level.to_string(),
-      "delta_order" => self.compressor_config.delta_encoding_order.map(|order| order.to_string()).unwrap_or("auto".to_string()),
+      "delta_order" => self
+        .compressor_config
+        .delta_encoding_order
+        .map(|order| order.to_string())
+        .unwrap_or("auto".to_string()),
       "use_gcds" => self.compressor_config.use_gcds.to_string(),
       "use_float_mult" => self.compressor_config.use_float_mult.to_string(),
       _ => panic!("bad conf"),

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -4,7 +4,6 @@ use crate::constants::Bitlen;
 use crate::data_types::UnsignedLike;
 use crate::errors::PcoResult;
 
-use crate::chunk_metadata::DataPageStreamMetadata;
 use crate::ChunkStreamMetadata;
 
 #[derive(Clone, Debug)]
@@ -49,7 +48,10 @@ impl Decoder {
     }
   }
 
-  pub fn from_stream_meta<U: UnsignedLike>(stream: &ChunkStreamMetadata<U>, final_state: usize) -> PcoResult<Self> {
+  pub fn from_stream_meta<U: UnsignedLike>(
+    stream: &ChunkStreamMetadata<U>,
+    final_state: usize,
+  ) -> PcoResult<Self> {
     let weights = stream.bins.iter().map(|bin| bin.weight).collect::<Vec<_>>();
     let spec = Spec::from_weights(stream.ans_size_log, weights)?;
     Ok(Self::new(&spec, final_state))

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -5,6 +5,7 @@ use crate::data_types::UnsignedLike;
 use crate::errors::PcoResult;
 
 use crate::chunk_metadata::DataPageStreamMetadata;
+use crate::ChunkStreamMetadata;
 
 #[derive(Clone, Debug)]
 struct Node {
@@ -48,10 +49,10 @@ impl Decoder {
     }
   }
 
-  pub fn from_stream_meta<U: UnsignedLike>(stream: &DataPageStreamMetadata<U>) -> PcoResult<Self> {
+  pub fn from_stream_meta<U: UnsignedLike>(stream: &ChunkStreamMetadata<U>, final_state: usize) -> PcoResult<Self> {
     let weights = stream.bins.iter().map(|bin| bin.weight).collect::<Vec<_>>();
     let spec = Spec::from_weights(stream.ans_size_log, weights)?;
-    Ok(Self::new(&spec, stream.ans_final_state))
+    Ok(Self::new(&spec, final_state))
   }
 
   #[inline]

--- a/pco/src/base_compressor.rs
+++ b/pco/src/base_compressor.rs
@@ -645,7 +645,7 @@ impl<T: NumberLike> BaseCompressor<T> {
     meta.write_to(&self.flags, &mut self.writer);
 
     let n_streams = optimized_mode.n_streams();
-    let (needs_gcds, n_nontrivial_streams) = meta.necessary_gcd_and_n_streams();
+    let (needs_gcds, n_nontrivial_streams) = meta.nontrivial_gcd_and_n_streams();
 
     self.state = State::MidChunk(MidChunkInfo {
       stream_configs,

--- a/pco/src/base_decompressor.rs
+++ b/pco/src/base_decompressor.rs
@@ -4,10 +4,10 @@ use std::io::Write;
 use crate::bit_reader::BitReader;
 use crate::bit_words::PaddedBytes;
 use crate::body_decompressor::BodyDecompressor;
-use crate::chunk_metadata::{ChunkMetadata, DataPageMetadata, DataPageStreamMetadata};
+use crate::chunk_metadata::{ChunkMetadata, DataPageMetadata};
 use crate::constants::{MAGIC_CHUNK_BYTE, MAGIC_HEADER, MAGIC_TERMINATION_BYTE};
 use crate::data_types::NumberLike;
-use crate::delta_encoding::DeltaMoments;
+
 use crate::errors::{PcoError, PcoResult};
 use crate::Flags;
 
@@ -124,7 +124,12 @@ impl<T: NumberLike> State<T> {
         PcoError::corruption("compressed page size {} is less than data page metadata size")
       })?;
 
-    BodyDecompressor::new(n, compressed_body_size, chunk_meta, data_page_meta)
+    BodyDecompressor::new(
+      n,
+      compressed_body_size,
+      chunk_meta,
+      data_page_meta,
+    )
   }
 
   pub fn step(&self) -> Step {

--- a/pco/src/base_decompressor.rs
+++ b/pco/src/base_decompressor.rs
@@ -112,42 +112,19 @@ impl<T: NumberLike> State<T> {
     n: usize,
     compressed_page_size: usize,
   ) -> PcoResult<BodyDecompressor<T>> {
-    let flags = self.flags.as_ref().unwrap();
     let chunk_meta = self.chunk_meta.as_ref().unwrap();
 
     let start_byte_idx = reader.aligned_byte_idx()?;
-
-    let mut streams = Vec::with_capacity(chunk_meta.streams.len());
-    for (stream_idx, chunk_stream_meta) in chunk_meta.streams.iter().enumerate() {
-      let delta_order = chunk_meta
-        .mode
-        .stream_delta_order(stream_idx, flags.delta_encoding_order);
-      let ans_size_log = chunk_stream_meta.ans_size_log;
-      let delta_moments = DeltaMoments::parse_from(reader, delta_order)?;
-      let ans_final_state = (1 << ans_size_log) + reader.read_usize(ans_size_log)?;
-      streams.push(DataPageStreamMetadata::new(
-        chunk_stream_meta,
-        delta_moments,
-        ans_final_state,
-      ));
-    }
-
-    reader.drain_empty_byte("non-zero bits at end of data page metadata")?;
+    let data_page_meta = DataPageMetadata::parse_from(reader, chunk_meta)?;
     let end_byte_idx = reader.aligned_byte_idx()?;
+
     let compressed_body_size = compressed_page_size
       .checked_sub(end_byte_idx - start_byte_idx)
       .ok_or_else(|| {
         PcoError::corruption("compressed page size {} is less than data page metadata size")
       })?;
 
-    let data_page_meta = DataPageMetadata {
-      compressed_body_size,
-      n,
-      mode: chunk_meta.mode,
-      streams,
-    };
-
-    BodyDecompressor::new(data_page_meta)
+    BodyDecompressor::new(n, compressed_body_size, chunk_meta, data_page_meta)
   }
 
   pub fn step(&self) -> Step {

--- a/pco/src/bin.rs
+++ b/pco/src/bin.rs
@@ -1,8 +1,7 @@
 use crate::ans::Token;
-use crate::chunk_metadata::DataPageStreamMetadata;
+
 use crate::constants::Bitlen;
 use crate::data_types::UnsignedLike;
-use crate::{ChunkStreamMetadata, Mode};
 
 /// Part of [`ChunkStreamMetadata`][`crate::ChunkStreamMetadata`] representing
 /// a numerical range.
@@ -82,5 +81,5 @@ impl<U: UnsignedLike> From<&Bin<U>> for BinDecompressionInfo<U> {
 }
 
 pub(crate) fn bins_are_trivial<U: UnsignedLike>(bins: &[Bin<U>]) -> bool {
-  bins.len() == 0 || (bins.len() == 1 && bins[0].offset_bits == 0)
+  bins.is_empty() || (bins.len() == 1 && bins[0].offset_bits == 0)
 }

--- a/pco/src/bin.rs
+++ b/pco/src/bin.rs
@@ -1,6 +1,8 @@
 use crate::ans::Token;
+use crate::chunk_metadata::DataPageStreamMetadata;
 use crate::constants::Bitlen;
 use crate::data_types::UnsignedLike;
+use crate::{ChunkStreamMetadata, Mode};
 
 /// Part of [`ChunkStreamMetadata`][`crate::ChunkStreamMetadata`] representing
 /// a numerical range.
@@ -77,4 +79,8 @@ impl<U: UnsignedLike> From<&Bin<U>> for BinDecompressionInfo<U> {
       gcd: bin.gcd,
     }
   }
+}
+
+pub(crate) fn bins_are_trivial<U: UnsignedLike>(bins: &[Bin<U>]) -> bool {
+  bins.len() == 0 || (bins.len() == 1 && bins[0].offset_bits == 0)
 }

--- a/pco/src/body_decompressor.rs
+++ b/pco/src/body_decompressor.rs
@@ -52,7 +52,7 @@ impl<T: NumberLike> BodyDecompressor<T> {
       mode: dyn_mode,
       num_decompressor,
       delta_momentss,
-      secondary_stream: [T::Unsigned::ZERO; UNSIGNED_BATCH_SIZE],
+      secondary_stream: [T::Unsigned::default(); UNSIGNED_BATCH_SIZE],
       phantom: PhantomData,
     })
   }
@@ -71,6 +71,13 @@ impl<T: NumberLike> BodyDecompressor<T> {
       delta_momentss,
       ..
     } = self;
+
+    if let Some(initial_value_required) = num_decompressor.initial_value_required(0) {
+      unsigneds_mut.fill(initial_value_required);
+    }
+    if let Some(initial_value_required) = num_decompressor.initial_value_required(1) {
+      self.secondary_stream.fill(initial_value_required);
+    }
 
     let progress = {
       let u_dst = UnsignedDst::new(unsigneds_mut, &mut self.secondary_stream);

--- a/pco/src/body_decompressor.rs
+++ b/pco/src/body_decompressor.rs
@@ -99,9 +99,17 @@ impl<T: NumberLike> BodyDecompressor<T> {
         }
       }
 
-      let progress = num_decompressor.decompress_unsigneds(reader, error_on_insufficient_data, &mut u_dst)?;
+      let progress = num_decompressor.decompress_unsigneds(
+        reader,
+        error_on_insufficient_data,
+        &mut u_dst,
+      )?;
 
-      for (stream_idx, delta_moments) in delta_momentss.iter_mut().take(self.mode.n_streams()).enumerate() {
+      for (stream_idx, delta_moments) in delta_momentss
+        .iter_mut()
+        .take(self.mode.n_streams())
+        .enumerate()
+      {
         delta_encoding::reconstruct_in_place(delta_moments, u_dst.stream(stream_idx));
       }
 

--- a/pco/src/body_decompressor.rs
+++ b/pco/src/body_decompressor.rs
@@ -10,7 +10,7 @@ use crate::errors::PcoResult;
 use crate::num_decompressor::NumDecompressor;
 use crate::progress::Progress;
 use crate::unsigned_src_dst::UnsignedDst;
-use crate::{ChunkMetadata, delta_encoding, float_mult_utils};
+use crate::{delta_encoding, float_mult_utils, ChunkMetadata};
 use crate::{num_decompressor, Mode};
 
 // BodyDecompressor wraps NumDecompressor and handles reconstruction from
@@ -40,13 +40,23 @@ fn join_streams<U: UnsignedLike>(mode: Mode<U>, dst: UnsignedDst<U>) {
 }
 
 impl<T: NumberLike> BodyDecompressor<T> {
-  pub(crate) fn new(n: usize, compressed_body_size: usize, chunk_meta: &ChunkMetadata<T::Unsigned>, data_page_meta: DataPageMetadata<T::Unsigned>) -> PcoResult<Self> {
+  pub(crate) fn new(
+    n: usize,
+    compressed_body_size: usize,
+    chunk_meta: &ChunkMetadata<T::Unsigned>,
+    data_page_meta: DataPageMetadata<T::Unsigned>,
+  ) -> PcoResult<Self> {
     let delta_momentss = data_page_meta
       .streams
       .iter()
       .map(|stream| stream.delta_moments.clone())
       .collect();
-    let num_decompressor = num_decompressor::new(n, compressed_body_size, chunk_meta, data_page_meta)?;
+    let num_decompressor = num_decompressor::new(
+      n,
+      compressed_body_size,
+      chunk_meta,
+      data_page_meta,
+    )?;
     Ok(Self {
       // we don't store the whole ChunkMeta because it can get large due to bins
       mode: chunk_meta.mode,

--- a/pco/src/chunk_metadata.rs
+++ b/pco/src/chunk_metadata.rs
@@ -317,7 +317,7 @@ impl<U: UnsignedLike> ChunkMetadata<U> {
     );
   }
 
-  pub(crate) fn necessary_gcd_and_n_streams(&self) -> (bool, usize) {
+  pub(crate) fn nontrivial_gcd_and_n_streams(&self) -> (bool, usize) {
     let primary_bins = &self.streams[0].bins;
     match self.mode {
       Mode::Classic | Mode::Gcd => {

--- a/pco/src/chunk_metadata.rs
+++ b/pco/src/chunk_metadata.rs
@@ -70,6 +70,10 @@ impl<'a, U: UnsignedLike> DataPageStreamMetadata<'a, U> {
       ans_final_state,
     }
   }
+
+  pub fn is_trivial(&self) -> bool {
+    self.bins.len() == 0 || (self.bins.len() == 1 && self.bins[0].offset_bits == 0)
+  }
 }
 
 /// The metadata of a pco chunk.

--- a/pco/src/flags.rs
+++ b/pco/src/flags.rs
@@ -100,8 +100,6 @@ impl Flags {
   }
 
   pub(crate) fn from_config(_config: &CompressorConfig, use_wrapped_mode: bool) -> Self {
-    Flags {
-      use_wrapped_mode,
-    }
+    Flags { use_wrapped_mode }
   }
 }

--- a/pco/src/flags.rs
+++ b/pco/src/flags.rs
@@ -5,7 +5,6 @@
 use crate::bit_reader::BitReader;
 use crate::bit_words::PaddedBytes;
 use crate::bit_writer::BitWriter;
-use crate::constants::{BITS_TO_ENCODE_DELTA_ENCODING_ORDER, MAX_DELTA_ENCODING_ORDER};
 use crate::errors::{ErrorKind, PcoError, PcoResult};
 use crate::CompressorConfig;
 
@@ -23,12 +22,6 @@ use crate::CompressorConfig;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct Flags {
-  /// How many times delta encoding was applied during compression.
-  /// This is stored as 3 bits to express 0-7.
-  /// See [`CompressorConfig`][crate::CompressorConfig] for more details.
-  ///
-  /// Introduced in 0.0.0.
-  pub delta_encoding_order: usize,
   /// Whether to the data is part of a wrapping format.
   /// This causes `pco` to omit count and compressed size metadata
   /// and also break each chunk into finer data pages.
@@ -39,7 +32,6 @@ pub struct Flags {
 
 impl Flags {
   fn core_parse_from(flags: &mut Flags, reader: &mut BitReader) -> PcoResult<()> {
-    flags.delta_encoding_order = reader.read_usize(BITS_TO_ENCODE_DELTA_ENCODING_ORDER)?;
     flags.use_wrapped_mode = reader.read_one()?;
 
     let compat_err =
@@ -63,7 +55,6 @@ impl Flags {
     let mut sub_reader = BitReader::from(&sub_bit_words);
 
     let mut flags = Flags {
-      delta_encoding_order: 0,
       use_wrapped_mode: false,
     };
     let parse_res = Self::core_parse_from(&mut flags, &mut sub_reader);
@@ -75,23 +66,14 @@ impl Flags {
   }
 
   pub(crate) fn write_to(&self, writer: &mut BitWriter) -> PcoResult<()> {
-    if self.delta_encoding_order > MAX_DELTA_ENCODING_ORDER {
-      return Err(PcoError::invalid_argument(format!(
-        "delta encoding order may not exceed {} (was {})",
-        MAX_DELTA_ENCODING_ORDER, self.delta_encoding_order,
-      )));
-    }
-
     let start_bit_idx = writer.bit_size();
     writer.write_aligned_byte(0)?; // to later be filled with # subsequent bytes
 
     let pre_byte_size = writer.byte_size();
 
-    writer.write_usize(
-      self.delta_encoding_order,
-      BITS_TO_ENCODE_DELTA_ENCODING_ORDER,
-    );
+    // write each flags here
     writer.write_one(self.use_wrapped_mode);
+    // done writing each flag
 
     writer.finish_byte();
     let byte_len = writer.byte_size() - pre_byte_size;
@@ -117,9 +99,8 @@ impl Flags {
     }
   }
 
-  pub(crate) fn from_config(config: &CompressorConfig, use_wrapped_mode: bool) -> Self {
+  pub(crate) fn from_config(_config: &CompressorConfig, use_wrapped_mode: bool) -> Self {
     Flags {
-      delta_encoding_order: config.delta_encoding_order,
       use_wrapped_mode,
     }
   }

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -3,7 +3,6 @@
 //! <https://github.com/mwlon/pcodec/tree/main/pco>.
 #![allow(clippy::uninit_vec)]
 
-pub use auto::auto_compressor_config;
 pub use base_compressor::CompressorConfig;
 pub use base_decompressor::DecompressorConfig;
 pub use bin::Bin;

--- a/pco/src/modes/mode.rs
+++ b/pco/src/modes/mode.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use crate::Bin;
 
 use crate::bin::{BinCompressionInfo, BinDecompressionInfo};
 use crate::bit_reader::BitReader;

--- a/pco/src/modes/mode.rs
+++ b/pco/src/modes/mode.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use crate::Bin;
 
 use crate::bin::{BinCompressionInfo, BinDecompressionInfo};
 use crate::bit_reader::BitReader;
@@ -59,16 +60,14 @@ impl<U: UnsignedLike> Mode<U> {
   pub(crate) fn n_streams(&self) -> usize {
     match self {
       Mode::Classic | Mode::Gcd => 1,
-      Mode::FloatMult { .. } => 2,
+      Mode::FloatMult(_) => 2,
     }
   }
 
   pub(crate) fn stream_delta_order(&self, stream_idx: usize, delta_order: usize) -> usize {
     match (self, stream_idx) {
-      (Mode::Classic, 0) => delta_order,
-      (Mode::Gcd, 0) => delta_order,
-      (Mode::FloatMult { .. }, 0) => delta_order,
-      (Mode::FloatMult { .. }, 1) => 0,
+      (Mode::Classic, 0) | (Mode::Gcd, 0) | (Mode::FloatMult(_), 0) => delta_order,
+      (Mode::FloatMult(_), 1) => 0,
       _ => panic!(
         "should be unreachable; unknown stream {:?}/{}",
         self, stream_idx

--- a/pco/src/num_decompressor.rs
+++ b/pco/src/num_decompressor.rs
@@ -73,7 +73,7 @@ pub trait NumDecompressor<U: UnsignedLike>: Debug {
     &mut self,
     reader: &mut BitReader,
     error_on_insufficient_data: bool,
-    dst: UnsignedDst<U>,
+    dst: &mut UnsignedDst<U>,
   ) -> PcoResult<Progress>;
 
   fn clone_inner(&self) -> Box<dyn NumDecompressor<U>>;
@@ -129,7 +129,7 @@ pub fn new<U: UnsignedLike>(
       .unwrap_or(Bitlen::MAX);
   }
 
-  let (needs_gcd, n_streams) = chunk_meta.necessary_gcd_and_n_streams();
+  let (needs_gcd, n_streams) = chunk_meta.nontrivial_gcd_and_n_streams();
 
   let mut initial_values_required = [None; MAX_N_STREAMS];
   for stream_idx in n_streams..MAX_N_STREAMS {
@@ -178,11 +178,11 @@ impl<U: UnsignedLike, M: ConstMode<U>, const STREAMS: usize> NumDecompressor<U>
     &mut self,
     reader: &mut BitReader,
     error_on_insufficient_data: bool,
-    mut dst: UnsignedDst<U>,
+    dst: &mut UnsignedDst<U>,
   ) -> PcoResult<Progress> {
     let initial_reader = reader.clone();
     let state_backup = self.state.backup();
-    let res = self.decompress_unsigneds_dirty(reader, error_on_insufficient_data, &mut dst);
+    let res = self.decompress_unsigneds_dirty(reader, error_on_insufficient_data, dst);
     match &res {
       Ok(progress) => {
         self.state.n_processed += progress.n_processed;

--- a/pco/src/standalone/compressor.rs
+++ b/pco/src/standalone/compressor.rs
@@ -30,20 +30,24 @@ pub struct Compressor<T: NumberLike>(BaseCompressor<T>);
 
 impl<T: NumberLike> Default for Compressor<T> {
   fn default() -> Self {
-    Self::from_config(CompressorConfig::default())
+    Self::from_config(CompressorConfig::default()).unwrap()
   }
 }
 
 impl<T: NumberLike> Compressor<T> {
   /// Creates a new compressor, given a [`CompressorConfig`].
+  ///
   /// Internally, the compressor builds [`Flags`] as well as an internal
   /// configuration that doesn't show up in the output file.
   /// You can inspect the flags it chooses with [`.flags()`][Self::flags].
-  pub fn from_config(config: CompressorConfig) -> Self {
-    Self(BaseCompressor::<T>::from_config(
+  ///
+  /// Will return an error if the compressor config is invalid.
+  pub fn from_config(config: CompressorConfig) -> PcoResult<Self> {
+    Ok(Self(BaseCompressor::<T>::from_config(
       config, false,
-    ))
+    )?))
   }
+
   /// Returns a reference to the compressor's flags.
   pub fn flags(&self) -> &Flags {
     &self.0.flags

--- a/pco/src/tests/atomicity.rs
+++ b/pco/src/tests/atomicity.rs
@@ -7,7 +7,7 @@ use crate::CompressorConfig;
 #[test]
 fn test_errors_do_not_mutate_decompressor() {
   let nums = vec![1, 2, 3, 4, 5];
-  let compressed = simple_compress(CompressorConfig::default(), &nums);
+  let compressed = simple_compress(&nums, CompressorConfig::default()).unwrap();
   let mut decompressor = Decompressor::<i32>::default();
 
   // header shouldn't leave us in a dirty state

--- a/pco/src/tests/low_level.rs
+++ b/pco/src/tests/low_level.rs
@@ -32,7 +32,8 @@ fn assert_lowest_level_behavior<T: NumberLike>(chunks: Vec<Vec<T>>) -> PcoResult
     let mut compressor = Compressor::<T>::from_config(CompressorConfig {
       delta_encoding_order: Some(delta_encoding_order),
       ..Default::default()
-    }).unwrap();
+    })
+    .unwrap();
     compressor.header()?;
     let mut metadatas = Vec::new();
     for nums in &chunks {

--- a/pco/src/tests/low_level.rs
+++ b/pco/src/tests/low_level.rs
@@ -30,9 +30,9 @@ fn assert_lowest_level_behavior<T: NumberLike>(chunks: Vec<Vec<T>>) -> PcoResult
   for delta_encoding_order in [0, 7] {
     let debug_info = format!("delta order={}", delta_encoding_order);
     let mut compressor = Compressor::<T>::from_config(CompressorConfig {
-      delta_encoding_order,
+      delta_encoding_order: Some(delta_encoding_order),
       ..Default::default()
-    });
+    }).unwrap();
     compressor.header()?;
     let mut metadatas = Vec::new();
     for nums in &chunks {

--- a/pco/src/tests/recovery.rs
+++ b/pco/src/tests/recovery.rs
@@ -221,10 +221,10 @@ fn assert_recovers_within_size<T: NumberLike>(
   );
   let config = CompressorConfig {
     compression_level,
-    delta_encoding_order,
+    delta_encoding_order: Some(delta_encoding_order),
     ..Default::default()
   };
-  let compressed = simple_compress(config, nums);
+  let compressed = simple_compress(nums, config)?;
   assert!(
     compressed.len() <= max_byte_size,
     "compressed size {} > {}; {}",

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -9,7 +9,8 @@ fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> ChunkMetadata<T::Unsigned> 
     use_gcds: false,
     delta_encoding_order: Some(0),
     ..Default::default()
-  }).unwrap();
+  })
+  .unwrap();
   compressor.header().expect("header");
   let metadata = compressor.chunk(&nums).expect("chunk");
   compressor.footer().expect("footer");

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -7,6 +7,7 @@ use crate::CompressorConfig;
 fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> ChunkMetadata<T::Unsigned> {
   let mut compressor = Compressor::from_config(CompressorConfig {
     use_gcds: false,
+    delta_encoding_order: Some(0),
     ..Default::default()
   }).unwrap();
   compressor.header().expect("header");

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -8,7 +8,7 @@ fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> ChunkMetadata<T::Unsigned> 
   let mut compressor = Compressor::from_config(CompressorConfig {
     use_gcds: false,
     ..Default::default()
-  });
+  }).unwrap();
   compressor.header().expect("header");
   let metadata = compressor.chunk(&nums).expect("chunk");
   compressor.footer().expect("footer");

--- a/pco/src/tests/utils.rs
+++ b/pco/src/tests/utils.rs
@@ -23,7 +23,7 @@ pub fn wrapped_compress<T: NumberLike>(
 ) -> PcoResult<Vec<u8>> {
   let mut res = Vec::new();
 
-  let mut compressor = Compressor::<T>::from_config(config);
+  let mut compressor = Compressor::<T>::from_config(config)?;
   compressor.header()?;
   let header = compressor.drain_bytes();
   res.extend(encode_usize(header.len()));

--- a/pco/src/tests/wrapped.rs
+++ b/pco/src/tests/wrapped.rs
@@ -6,7 +6,7 @@ use crate::{CompressorConfig, DecompressorConfig};
 fn test_dummy_wrapped_format_recovery() -> PcoResult<()> {
   let nums = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   let config = CompressorConfig {
-    delta_encoding_order: 2,
+    delta_encoding_order: Some(2),
     ..Default::default()
   };
   let sizess = vec![vec![4, 2, 1], vec![3]];

--- a/pco/src/unsigned_src_dst.rs
+++ b/pco/src/unsigned_src_dst.rs
@@ -110,6 +110,14 @@ impl<'a, U: UnsignedLike> UnsignedDst<'a, U> {
     }
   }
 
+  pub fn stream(&mut self, stream_idx: usize) -> &mut [U] {
+    match stream_idx {
+      0 => self.primary_stream,
+      1 => self.stream1,
+      _ => panic!("invalid stream; should be unreachable"),
+    }
+  }
+
   pub fn n_processed(&self) -> usize {
     self.i
   }

--- a/pco/src/wrapped/compressor.rs
+++ b/pco/src/wrapped/compressor.rs
@@ -17,19 +17,22 @@ pub struct Compressor<T: NumberLike>(BaseCompressor<T>);
 
 impl<T: NumberLike> Default for Compressor<T> {
   fn default() -> Self {
-    Self::from_config(CompressorConfig::default())
+    Self::from_config(CompressorConfig::default()).unwrap()
   }
 }
 
 impl<T: NumberLike> Compressor<T> {
   /// Creates a new compressor, given a [`CompressorConfig`].
+  ///
   /// Internally, the compressor builds [`Flags`] as well as an internal
   /// configuration that doesn't show up in the output file.
   /// You can inspect the flags it chooses with [`.flags()`][Self::flags].
-  pub fn from_config(config: CompressorConfig) -> Self {
-    Self(BaseCompressor::<T>::from_config(
+  ///
+  /// Will return an error if the compressor config is invalid.
+  pub fn from_config(config: CompressorConfig) -> PcoResult<Self> {
+    Ok(Self(BaseCompressor::<T>::from_config(
       config, true,
-    ))
+    )?))
   }
 
   /// Returns a reference to the compressor's flags.

--- a/pco_cli/src/inspect_handler.rs
+++ b/pco_cli/src/inspect_handler.rs
@@ -123,7 +123,7 @@ impl<P: NumberLikeArrow> InspectHandler for HandlerImpl<P> {
         };
         let show_as_float_int = matches!(m.mode, Mode::FloatMult { .. }) && stream_idx == 0;
         let show_as_delta = (matches!(m.mode, Mode::FloatMult { .. }) && stream_idx == 1)
-          || flags.delta_encoding_order > 0;
+          || m.delta_encoding_order > 0;
         println!(
           "stream: {} n_bins: {} ANS size log: {}",
           stream_name,


### PR DESCRIPTION
Use faster loops for more trivial cases. This also paves the way to enabling optional lossy float mult compression and decompression