### PR TITLE
Renamings

### DIFF
--- a/bench/src/codecs/pco.rs
+++ b/bench/src/codecs/pco.rs
@@ -1,7 +1,7 @@
 use crate::codecs::CodecInternal;
 use crate::dtypes::Dtype;
 use anyhow::{anyhow, Result};
-use pco::PagingSpec;
+use pco::{FloatMultSpec, GcdSpec, PagingSpec};
 
 #[derive(Clone, Debug, Default)]
 pub struct PcoConfig {
@@ -21,8 +21,8 @@ impl CodecInternal for PcoConfig {
         .delta_encoding_order
         .map(|order| order.to_string())
         .unwrap_or("auto".to_string()),
-      "use_gcds" => self.compressor_config.use_gcds.to_string(),
-      "use_float_mult" => self.compressor_config.use_float_mult.to_string(),
+      "gcd" => format!("{:?}", self.compressor_config.gcd_spec),
+      "float_mult" => format!("{:?}", self.compressor_config.float_mult_spec),
       "page_size" => match self.compressor_config.paging_spec {
         PagingSpec::EqualPagesUpTo(page_size) => page_size.to_string(),
         _ => panic!("unexpected paging spec"),
@@ -32,6 +32,7 @@ impl CodecInternal for PcoConfig {
   }
 
   fn set_conf(&mut self, key: &str, value: String) -> Result<()> {
+    let value = value.to_lowercase();
     match key {
       "level" => self.compressor_config.compression_level = value.parse::<usize>().unwrap(),
       "delta_order" => {
@@ -46,8 +47,22 @@ impl CodecInternal for PcoConfig {
           ));
         }
       }
-      "use_gcds" => self.compressor_config.use_gcds = value.parse::<bool>().unwrap(),
-      "use_float_mult" => self.compressor_config.use_float_mult = value.parse::<bool>().unwrap(),
+      "gcd" => self.compressor_config.gcd_spec = match value.as_str() {
+        "enabled" => GcdSpec::Enabled,
+        "disabled" => GcdSpec::Disabled,
+        other => return Err(anyhow!(
+          "cannot parse gcd: {}",
+          other,
+        ))
+      },
+      "float_mult" => self.compressor_config.float_mult_spec = match value.as_str() {
+        "enabled" => FloatMultSpec::Enabled,
+        "disabled" => FloatMultSpec::Disabled,
+        other => return Err(anyhow!(
+          "cannot parse float mult: {}",
+          other,
+        ))
+      },
       "page_size" => {
         self.compressor_config.paging_spec = PagingSpec::EqualPagesUpTo(value.parse().unwrap())
       }

--- a/bench/src/codecs/pco.rs
+++ b/bench/src/codecs/pco.rs
@@ -22,7 +22,10 @@ impl CodecInternal for PcoConfig {
         .map(|order| order.to_string())
         .unwrap_or("auto".to_string()),
       "gcd" => format!("{:?}", self.compressor_config.gcd_spec),
-      "float_mult" => format!("{:?}", self.compressor_config.float_mult_spec),
+      "float_mult" => format!(
+        "{:?}",
+        self.compressor_config.float_mult_spec
+      ),
       "page_size" => match self.compressor_config.paging_spec {
         PagingSpec::EqualPagesUpTo(page_size) => page_size.to_string(),
         _ => panic!("unexpected paging spec"),
@@ -47,22 +50,20 @@ impl CodecInternal for PcoConfig {
           ));
         }
       }
-      "gcd" => self.compressor_config.gcd_spec = match value.as_str() {
-        "enabled" => GcdSpec::Enabled,
-        "disabled" => GcdSpec::Disabled,
-        other => return Err(anyhow!(
-          "cannot parse gcd: {}",
-          other,
-        ))
-      },
-      "float_mult" => self.compressor_config.float_mult_spec = match value.as_str() {
-        "enabled" => FloatMultSpec::Enabled,
-        "disabled" => FloatMultSpec::Disabled,
-        other => return Err(anyhow!(
-          "cannot parse float mult: {}",
-          other,
-        ))
-      },
+      "gcd" => {
+        self.compressor_config.gcd_spec = match value.as_str() {
+          "enabled" => GcdSpec::Enabled,
+          "disabled" => GcdSpec::Disabled,
+          other => return Err(anyhow!("cannot parse gcd: {}", other,)),
+        }
+      }
+      "float_mult" => {
+        self.compressor_config.float_mult_spec = match value.as_str() {
+          "enabled" => FloatMultSpec::Enabled,
+          "disabled" => FloatMultSpec::Disabled,
+          other => return Err(anyhow!("cannot parse float mult: {}", other,)),
+        }
+      }
       "page_size" => {
         self.compressor_config.paging_spec = PagingSpec::EqualPagesUpTo(value.parse().unwrap())
       }

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -41,7 +41,9 @@ impl Decoder {
     Self { nodes }
   }
 
-  pub fn from_chunk_latent_var_meta<U: UnsignedLike>(latent_meta: &ChunkLatentVarMeta<U>) -> PcoResult<Self> {
+  pub fn from_chunk_latent_var_meta<U: UnsignedLike>(
+    latent_meta: &ChunkLatentVarMeta<U>,
+  ) -> PcoResult<Self> {
     let weights = latent_meta
       .bins
       .iter()

--- a/pco/src/ans/decoding.rs
+++ b/pco/src/ans/decoding.rs
@@ -3,7 +3,7 @@ use crate::ans::{AnsState, Token};
 use crate::constants::Bitlen;
 use crate::data_types::UnsignedLike;
 use crate::errors::PcoResult;
-use crate::ChunkLatentMeta;
+use crate::ChunkLatentVarMeta;
 
 #[derive(Clone, Debug)]
 pub struct Node {
@@ -41,7 +41,7 @@ impl Decoder {
     Self { nodes }
   }
 
-  pub fn from_latent_meta<U: UnsignedLike>(latent_meta: &ChunkLatentMeta<U>) -> PcoResult<Self> {
+  pub fn from_chunk_latent_var_meta<U: UnsignedLike>(latent_meta: &ChunkLatentVarMeta<U>) -> PcoResult<Self> {
     let weights = latent_meta
       .bins
       .iter()

--- a/pco/src/ans/mod.rs
+++ b/pco/src/ans/mod.rs
@@ -33,8 +33,8 @@ mod tests {
       state = new_state;
     }
 
-    let mut bytes = Vec::new();
-    let mut writer = BitWriter::new(&mut bytes, 5);
+    let mut compressed = Vec::new();
+    let mut writer = BitWriter::new(&mut compressed, 5);
     for (word, bitlen) in to_write.into_iter().rev() {
       writer.write_uint(word, bitlen);
       writer.flush()?;
@@ -42,14 +42,14 @@ mod tests {
     writer.finish_byte();
     writer.flush()?;
     drop(writer);
-    assert_eq!(bytes.len(), expected_byte_len);
+    assert_eq!(compressed.len(), expected_byte_len);
     let final_state = state;
     let table_size = 1 << encoder.size_log();
 
     // DECODE
     let decoder = Decoder::new(spec);
-    let extension = bit_reader::make_extension_for(&bytes, 100);
-    let mut reader = BitReader::new(&bytes, &extension);
+    let extension = bit_reader::make_extension_for(&compressed, 100);
+    let mut reader = BitReader::new(&compressed, &extension);
     let mut decoded = Vec::new();
     let mut state_idx = final_state - table_size;
     for _ in 0..tokens.len() {

--- a/pco/src/auto.rs
+++ b/pco/src/auto.rs
@@ -4,8 +4,8 @@ use crate::chunk_config::{ChunkConfig, PagingSpec};
 use crate::constants::{AUTO_DELTA_LIMIT, MAX_AUTO_DELTA_COMPRESSION_LEVEL};
 use crate::data_types::NumberLike;
 use crate::errors::PcoResult;
-use crate::{FloatMultSpec, GcdSpec};
 use crate::wrapped::FileCompressor;
+use crate::{FloatMultSpec, GcdSpec};
 
 /// Automatically makes an educated guess for the best compression
 /// delta encoding order, based on `nums` and `compression_level`.

--- a/pco/src/auto.rs
+++ b/pco/src/auto.rs
@@ -4,6 +4,7 @@ use crate::chunk_config::{ChunkConfig, PagingSpec};
 use crate::constants::{AUTO_DELTA_LIMIT, MAX_AUTO_DELTA_COMPRESSION_LEVEL};
 use crate::data_types::NumberLike;
 use crate::errors::PcoResult;
+use crate::{FloatMultSpec, GcdSpec};
 use crate::wrapped::FileCompressor;
 
 /// Automatically makes an educated guess for the best compression
@@ -47,8 +48,8 @@ pub fn auto_delta_encoding_order<T: NumberLike>(
         compression_level,
         MAX_AUTO_DELTA_COMPRESSION_LEVEL,
       ),
-      use_gcds: false,
-      use_float_mult: true,
+      gcd_spec: GcdSpec::Disabled,
+      float_mult_spec: FloatMultSpec::Enabled,
       paging_spec: PagingSpec::default(),
     };
     let fc = FileCompressor::default();

--- a/pco/src/bin.rs
+++ b/pco/src/bin.rs
@@ -2,7 +2,7 @@ use crate::ans::Token;
 use crate::constants::{Bitlen, Weight};
 use crate::data_types::UnsignedLike;
 
-/// Part of [`ChunkLatentMeta`][`crate::ChunkLatentMeta`] representing
+/// Part of [`ChunkLatentVarMeta`][`crate::ChunkLatentVarMeta`] representing
 /// a numerical range.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]

--- a/pco/src/chunk_config.rs
+++ b/pco/src/chunk_config.rs
@@ -1,6 +1,41 @@
-use crate::constants::DEFAULT_MAX_PAGE_SIZE;
+use crate::constants::DEFAULT_MAX_PAGE_N;
 use crate::errors::{PcoError, PcoResult};
 use crate::{bits, DEFAULT_COMPRESSION_LEVEL};
+
+/// Configures whether per-bin Greatest Common Divisor detection is enabled.
+///
+/// Examples where this helps:
+/// * nanosecond-precision timestamps that are all whole numbers of
+/// microseconds
+/// * integers `[7, 107, 207, 307, ... 100007]` shuffled
+///
+/// When this is helpful, compression and decompression speeds are slightly
+/// reduced. In rare cases, this configuration may reduce
+/// compression speed slightly even when it isn't helpful.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GcdSpec {
+  Disabled,
+  #[default]
+  Enabled,
+}
+
+/// Configures whether per-chunk float multiplier detection is enabled.
+///
+/// Examples where this helps:
+/// * approximate multiples of 0.01
+/// * approximate multiples of pi
+///
+/// Float mults can work even when there are NaNs and infinities.
+/// When this is helpful, compression and decompression speeds can be
+/// substantially reduced. In rare cases, this configuration
+/// may reduce compression speed somewhat even when it isn't helpful.
+/// However, the compression ratio improvements tend to be quite large.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FloatMultSpec {
+  Disabled,
+  #[default]
+  Enabled,
+}
 
 /// All configurations available for a compressor.
 ///
@@ -11,7 +46,7 @@ use crate::{bits, DEFAULT_COMPRESSION_LEVEL};
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ChunkConfig {
-  /// `compression_level` ranges from 0 to 12 inclusive (default 8).
+  /// `compression_level` ranges from 0 to 12 inclusive (default: 8).
   ///
   /// The compressor uses up to 2^`compression_level` bins.
   ///
@@ -22,8 +57,8 @@ pub struct ChunkConfig {
   /// * Level 12 can marginally better compression than 8 with 4096
   /// bins, but may run several times slower.
   pub compression_level: usize,
-  /// `delta_encoding_order` ranges from 0 to 7 inclusive (defaults to
-  /// automatically detecting on each chunk).
+  /// `delta_encoding_order` ranges from 0 to 7 inclusive (default:
+  /// `None`, automatically detecting on each chunk).
   ///
   /// It is the number of times to apply delta encoding
   /// before compressing. For instance, say we have the numbers
@@ -43,33 +78,21 @@ pub struct ChunkConfig {
   /// chunks,
   /// [`auto_compressor_config()`][crate::auto_delta_encoding_order] can help.
   pub delta_encoding_order: Option<usize>,
-  /// `use_gcds` improves compression ratio in cases where all
+  /// GCDs improve compression ratio in cases where all
   /// numbers in a bin share a nontrivial Greatest Common Divisor
-  /// (default true).
+  /// (default: `Enabled`).
   ///
-  /// Examples where this helps:
-  /// * nanosecond-precision timestamps that are all whole numbers of
-  /// microseconds
-  /// * integers `[7, 107, 207, 307, ... 100007]` shuffled
+  /// See [`GcdSpec`][crate::GcdSpec] for more detail.
+  pub gcd_spec: GcdSpec,
+  /// Float multiplier mode improves compression ratio in cases where the data
+  /// type is a float and all numbers are close to a multiple of a float
+  /// `base`
+  /// (default: `Enabled`).
   ///
-  /// When this is helpful, compression and decompression speeds are slightly
-  /// reduced (up to ~15%). In rare cases, this configuration may reduce
-  /// compression speed even when it isn't helpful.
-  pub use_gcds: bool,
-  /// `use_float_mult` improves compression ratio in cases where the data type
-  /// is a float and all numbers are close to a multiple of a single float
-  /// `base`.
-  /// (default true).
-  ///
-  /// `base` is automatically detected. For example, this is helpful if all
-  /// floats are approximately decimals (multiples of 0.01).
-  ///
-  /// When this is helpful, compression and decompression speeds are
-  /// substantially reduced (up to ~50%). In rare cases, this configuration
-  /// may reduce compression speed somewhat even when it isn't helpful.
-  /// However, the compression ratio improvements tend to be quite large.
-  pub use_float_mult: bool,
+  /// See [`FloatMultSpec`][crate::FloatMultSpec] for more detail.
+  pub float_mult_spec: FloatMultSpec,
   /// `paging_spec` specifies how the chunk should be split into pages
+  /// (default: equal pages up to 1,000,000 numbers each).
   ///
   /// See [`PagingSpec`][crate::PagingSpec] for more information.
   pub paging_spec: PagingSpec,
@@ -80,9 +103,9 @@ impl Default for ChunkConfig {
     Self {
       compression_level: DEFAULT_COMPRESSION_LEVEL,
       delta_encoding_order: None,
-      use_gcds: true,
-      use_float_mult: true,
-      paging_spec: Default::default(),
+      gcd_spec: GcdSpec::Enabled,
+      float_mult_spec: FloatMultSpec::Enabled,
+      paging_spec: PagingSpec::EqualPagesUpTo(DEFAULT_MAX_PAGE_N),
     }
   }
 }
@@ -100,9 +123,15 @@ impl ChunkConfig {
     self
   }
 
-  /// Sets [`use_gcds`][ChunkConfig::use_gcds].
-  pub fn with_use_gcds(mut self, use_gcds: bool) -> Self {
-    self.use_gcds = use_gcds;
+  /// Sets [`gcd_spec`][ChunkConfig::gcd_spec].
+  pub fn with_gcd_spec(mut self, gcd_spec: GcdSpec) -> Self {
+    self.gcd_spec = gcd_spec;
+    self
+  }
+
+  /// Sets [`float_mult_spec`][ChunkConfig::float_mult_spec].
+  pub fn with_float_mult_spec(mut self, float_mult_spec: FloatMultSpec) -> Self {
+    self.float_mult_spec = float_mult_spec;
     self
   }
 
@@ -117,28 +146,27 @@ impl ChunkConfig {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum PagingSpec {
-  /// Divide the chunk into equal pages of up to the provided size in numbers.
+  /// Divide the chunk into equal pages of up to this many numbers.
   ///
-  /// For example, with a default size of 100,000, a chunk of size 150,000
-  /// would be divided into 2 pages, each of 75,000 numbers.
+  /// For example, with equal pages up to 100,000, a chunk of 150,000
+  /// numbers would be divided into 2 pages, each of 75,000 numbers.
   EqualPagesUpTo(usize),
-  /// Divide the chunk into the exactly provdided sizes.
+  /// Divide the chunk into the exactly provided counts.
   ///
-  /// If any of the sizes are 0 or the chunk size does not equal the sum,
-  /// you will get an InvalidArgument error during compression.
+  /// Will return an InvalidArgument error during compression if
+  /// any of the counts are 0 or the sum does not equal the chunk count.
   ExactPageSizes(Vec<usize>),
 }
 
-/// Default: equal pages up to 1,000,000 numbers each.
 impl Default for PagingSpec {
   fn default() -> Self {
-    Self::EqualPagesUpTo(DEFAULT_MAX_PAGE_SIZE)
+    Self::EqualPagesUpTo(DEFAULT_MAX_PAGE_N)
   }
 }
 
 impl PagingSpec {
-  pub(crate) fn page_sizes(&self, n: usize) -> PcoResult<Vec<usize>> {
-    let page_sizes = match self {
+  pub(crate) fn n_per_page(&self, n: usize) -> PcoResult<Vec<usize>> {
+    let n_per_page = match self {
       PagingSpec::EqualPagesUpTo(max_size) => {
         let n_pages = bits::ceil_div(n, *max_size);
         let mut res = Vec::new();
@@ -150,25 +178,25 @@ impl PagingSpec {
         }
         res
       }
-      PagingSpec::ExactPageSizes(sizes) => sizes.to_vec(),
+      PagingSpec::ExactPageSizes(n_per_page) => n_per_page.to_vec(),
     };
 
-    let sizes_n: usize = page_sizes.iter().sum();
-    if sizes_n != n {
+    let summed_n: usize = n_per_page.iter().sum();
+    if summed_n != n {
       return Err(PcoError::invalid_argument(format!(
         "paging spec suggests {} numbers but {} were given",
-        sizes_n, n,
+        summed_n, n,
       )));
     }
 
-    for &size in &page_sizes {
-      if size == 0 {
+    for &page_n in &n_per_page {
+      if page_n == 0 {
         return Err(PcoError::invalid_argument(
           "cannot write data page of 0 numbers",
         ));
       }
     }
 
-    Ok(page_sizes)
+    Ok(n_per_page)
   }
 }

--- a/pco/src/compression_intermediates.rs
+++ b/pco/src/compression_intermediates.rs
@@ -4,7 +4,7 @@ use crate::data_types::UnsignedLike;
 use crate::delta::DeltaMoments;
 
 #[derive(Clone, Debug)]
-pub struct PageVarLatents<U: UnsignedLike> {
+struct PageVarLatents<U: UnsignedLike> {
   pub latents: Vec<U>,
   pub delta_moments: DeltaMoments<U>,
 }
@@ -12,27 +12,26 @@ pub struct PageVarLatents<U: UnsignedLike> {
 #[derive(Clone, Debug)]
 pub struct PageLatents<U: UnsignedLike> {
   pub page_n: usize,
-  // one per latent variable
-  pub vars: Vec<PageVarLatents<U>>,
+  pub per_var: Vec<PageVarLatents<U>>, // on per latent variable
 }
 
 impl<U: UnsignedLike> PageLatents<U> {
-  pub fn new_pre_delta(latents: Vec<Vec<U>>) -> Self {
-    let page_n = latents[0].len();
-    let vars = latents
+  pub fn new_pre_delta(latents_per_var: Vec<Vec<U>>) -> Self {
+    let page_n = latents_per_var[0].len();
+    let per_var = latents_per_var
       .into_iter()
       .map(|latents| PageVarLatents {
         latents,
         delta_moments: DeltaMoments::default(),
       })
       .collect::<Vec<_>>();
-    Self { page_n, vars }
+    Self { page_n, per_var }
   }
 }
 
 #[derive(Clone, Debug)]
-pub struct DissectedLatents<U: UnsignedLike> {
-  // ans_vals and offsets should have the same length
+pub struct DissectedPageVar<U: UnsignedLike> {
+  // these vecs should have the same length
   pub ans_vals: Vec<AnsState>,
   pub ans_bits: Vec<Bitlen>,
   pub offsets: Vec<U>,
@@ -41,7 +40,7 @@ pub struct DissectedLatents<U: UnsignedLike> {
 }
 
 #[derive(Clone, Debug)]
-pub struct DissectedSrc<U: UnsignedLike> {
+pub struct DissectedPage<U: UnsignedLike> {
   pub page_n: usize,
-  pub dissected_latents: Vec<DissectedLatents<U>>, // one per latent variable
+  pub per_var: Vec<DissectedPageVar<U>>, // one per latent variable
 }

--- a/pco/src/compression_intermediates.rs
+++ b/pco/src/compression_intermediates.rs
@@ -4,7 +4,7 @@ use crate::data_types::UnsignedLike;
 use crate::delta::DeltaMoments;
 
 #[derive(Clone, Debug)]
-struct PageVarLatents<U: UnsignedLike> {
+pub struct PageVarLatents<U: UnsignedLike> {
   pub latents: Vec<U>,
   pub delta_moments: DeltaMoments<U>,
 }

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -30,7 +30,7 @@ pub const PAGE_LATENT_META_PADDING: usize =
 // Page padding is enough for one full batch of latents; this should also
 // generously cover the data needed to read the page meta.
 pub const PAGE_PADDING: usize =
-  FULL_BATCH_SIZE * (MAX_SUPPORTED_PRECISION_BYTES + MAX_ANS_BYTES) + OVERSHOOT_PADDING;
+  FULL_BATCH_N * (MAX_SUPPORTED_PRECISION_BYTES + MAX_ANS_BYTES) + OVERSHOOT_PADDING;
 
 // cutoffs and legal parameter values
 pub const AUTO_DELTA_LIMIT: usize = 1100;
@@ -46,14 +46,14 @@ pub const MAX_SUPPORTED_PRECISION_BYTES: usize = (MAX_SUPPORTED_PRECISION / 8) a
 // defaults
 pub const DEFAULT_COMPRESSION_LEVEL: usize = 8;
 // if you modify default page size, update docs for PagingSpec
-pub const DEFAULT_MAX_PAGE_SIZE: usize = 1000000;
+pub const DEFAULT_MAX_PAGE_N: usize = 1000000;
 
 // important parts of the format specification
 pub const ANS_INTERLEAVING: usize = 4;
 /// The count of numbers per batch, the smallest unit of decompression.
 ///
 /// Only the final batch in each page may have fewer numbers than this.
-pub const FULL_BATCH_SIZE: usize = 256;
+pub const FULL_BATCH_N: usize = 256;
 pub const FULL_BIN_BATCH_SIZE: usize = 128;
 
 #[cfg(test)]

--- a/pco/src/constants.rs
+++ b/pco/src/constants.rs
@@ -25,7 +25,7 @@ pub const OVERSHOOT_PADDING: usize = MAX_SUPPORTED_PRECISION_BYTES + 9;
 // generously cover the data needed to read the other parts of chunk meta.
 pub const CHUNK_META_PADDING: usize =
   FULL_BIN_BATCH_SIZE * (4 + 2 * MAX_SUPPORTED_PRECISION_BYTES) + OVERSHOOT_PADDING;
-pub const PAGE_LATENT_META_PADDING: usize =
+pub const PAGE_LATENT_VAR_META_PADDING: usize =
   MAX_DELTA_ENCODING_ORDER * MAX_SUPPORTED_PRECISION_BYTES + MAX_ANS_BYTES + OVERSHOOT_PADDING;
 // Page padding is enough for one full batch of latents; this should also
 // generously cover the data needed to read the page meta.

--- a/pco/src/delta.rs
+++ b/pco/src/delta.rs
@@ -61,6 +61,8 @@ fn first_order_encode_in_place<U: UnsignedLike>(unsigneds: &mut Vec<U>) {
 // used for a single page, so we return the delta moments
 #[inline(never)]
 pub fn encode_in_place<U: UnsignedLike>(unsigneds: &mut Vec<U>, order: usize) -> DeltaMoments<U> {
+  // TODO this function could be made faster by doing all steps on mini batches
+  // of ~512 at a time
   if order == 0 {
     // exit early so we don't toggle to signed values
     return DeltaMoments::default();

--- a/pco/src/float_mult_utils.rs
+++ b/pco/src/float_mult_utils.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::constants::Bitlen;
 use crate::data_types::{FloatLike, NumberLike, UnsignedLike};
 use crate::delta;
-use crate::unsigned_src_dst::PageLatents;
+use crate::compression_intermediates::PageLatents;
 
 const ARITH_CHUNK_SIZE: usize = 512;
 

--- a/pco/src/float_mult_utils.rs
+++ b/pco/src/float_mult_utils.rs
@@ -1,10 +1,10 @@
 use std::cmp::{max, min};
 use std::collections::HashMap;
 
+use crate::compression_intermediates::PageLatents;
 use crate::constants::Bitlen;
 use crate::data_types::{FloatLike, NumberLike, UnsignedLike};
 use crate::delta;
-use crate::compression_intermediates::PageLatents;
 
 const ARITH_CHUNK_SIZE: usize = 512;
 

--- a/pco/src/latent_batch_decompressor.rs
+++ b/pco/src/latent_batch_decompressor.rs
@@ -113,12 +113,12 @@ impl<U: UnsignedLike> LatentBatchDecompressor<U> {
       for j in 0..MAX_ANS_SYMBOLS_PER_U64 {
         let i = base_i + j;
         let node = self.decoder.get_node(state_idxs[j]);
-        let state_offset = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
+        let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
         let info = unsafe { self.infos.get_unchecked(node.token as usize) };
         self.state.set_scratch(i, offset_bit_idx, info);
         bits_past_byte += node.bits_to_read;
         offset_bit_idx += info.offset_bits as usize;
-        state_idxs[j] = node.next_state_idx_base + state_offset;
+        state_idxs[j] = node.next_state_idx_base + ans_val;
       }
     }
 
@@ -140,12 +140,12 @@ impl<U: UnsignedLike> LatentBatchDecompressor<U> {
       bits_past_byte %= 8;
       let packed = bit_reader::u64_at(stream, stale_byte_idx);
       let node = self.decoder.get_node(state_idxs[j]);
-      let state_offset = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
+      let ans_val = (packed >> bits_past_byte) as AnsState & ((1 << node.bits_to_read) - 1);
       let info = &self.infos[node.token as usize];
       self.state.set_scratch(i, offset_bit_idx, info);
       bits_past_byte += node.bits_to_read;
       offset_bit_idx += info.offset_bits as usize;
-      state_idxs[j] = node.next_state_idx_base + state_offset;
+      state_idxs[j] = node.next_state_idx_base + ans_val;
     }
 
     reader.stale_byte_idx = stale_byte_idx;

--- a/pco/src/latent_batch_dissector.rs
+++ b/pco/src/latent_batch_dissector.rs
@@ -2,10 +2,10 @@ use std::cmp::min;
 
 use crate::ans;
 use crate::ans::{AnsState, Token};
+use crate::compression_intermediates::DissectedPageVar;
 use crate::compression_table::CompressionTable;
 use crate::constants::{Bitlen, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::UnsignedLike;
-use crate::compression_intermediates::DissectedPageVar;
 
 pub struct LatentBatchDissector<'a, U: UnsignedLike> {
   // immutable

--- a/pco/src/latent_batch_dissector.rs
+++ b/pco/src/latent_batch_dissector.rs
@@ -5,7 +5,7 @@ use crate::ans::{AnsState, Token};
 use crate::compression_table::CompressionTable;
 use crate::constants::{Bitlen, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::UnsignedLike;
-use crate::unsigned_src_dst::DissectedLatents;
+use crate::compression_intermediates::DissectedPageVar;
 
 pub struct LatentBatchDissector<'a, U: UnsignedLike> {
   // immutable
@@ -120,9 +120,9 @@ impl<'a, U: UnsignedLike> LatentBatchDissector<'a, U> {
     &mut self,
     latents: &[U],
     base_i: usize,
-    dst: &mut DissectedLatents<U>,
+    dst: &mut DissectedPageVar<U>,
   ) {
-    let DissectedLatents {
+    let DissectedPageVar {
       ans_vals,
       ans_bits,
       offsets,

--- a/pco/src/latent_batch_dissector.rs
+++ b/pco/src/latent_batch_dissector.rs
@@ -3,7 +3,7 @@ use std::cmp::min;
 use crate::ans;
 use crate::ans::{AnsState, Token};
 use crate::compression_table::CompressionTable;
-use crate::constants::{Bitlen, ANS_INTERLEAVING, FULL_BATCH_SIZE};
+use crate::constants::{Bitlen, ANS_INTERLEAVING, FULL_BATCH_N};
 use crate::data_types::UnsignedLike;
 use crate::unsigned_src_dst::DissectedLatents;
 
@@ -14,9 +14,9 @@ pub struct LatentBatchDissector<'a, U: UnsignedLike> {
   encoder: &'a ans::Encoder,
 
   // mutable
-  lower_scratch: [U; FULL_BATCH_SIZE],
-  gcd_scratch: [U; FULL_BATCH_SIZE],
-  token_scratch: [Token; FULL_BATCH_SIZE],
+  lower_scratch: [U; FULL_BATCH_N],
+  gcd_scratch: [U; FULL_BATCH_N],
+  token_scratch: [Token; FULL_BATCH_N],
 }
 
 impl<'a, U: UnsignedLike> LatentBatchDissector<'a, U> {
@@ -25,15 +25,15 @@ impl<'a, U: UnsignedLike> LatentBatchDissector<'a, U> {
       needs_gcd,
       table,
       encoder,
-      lower_scratch: [U::ZERO; FULL_BATCH_SIZE],
-      gcd_scratch: [U::ZERO; FULL_BATCH_SIZE],
-      token_scratch: [0; FULL_BATCH_SIZE],
+      lower_scratch: [U::ZERO; FULL_BATCH_N],
+      gcd_scratch: [U::ZERO; FULL_BATCH_N],
+      token_scratch: [0; FULL_BATCH_N],
     }
   }
 
   #[inline(never)]
-  fn binary_search(&self, latents: &[U]) -> [usize; FULL_BATCH_SIZE] {
-    let mut search_idxs = [0; FULL_BATCH_SIZE];
+  fn binary_search(&self, latents: &[U]) -> [usize; FULL_BATCH_N] {
+    let mut search_idxs = [0; FULL_BATCH_N];
 
     // we do this as `size_log` SIMD loops over the batch
     for depth in 0..self.table.search_size_log {
@@ -132,7 +132,7 @@ impl<'a, U: UnsignedLike> LatentBatchDissector<'a, U> {
 
     let search_idxs = self.binary_search(latents);
 
-    let end_i = min(base_i + FULL_BATCH_SIZE, ans_vals.len());
+    let end_i = min(base_i + FULL_BATCH_N, ans_vals.len());
 
     self.dissect_bins(
       &search_idxs[..latents.len()],

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -5,9 +5,9 @@
 
 pub use auto::auto_delta_encoding_order;
 pub use bin::Bin;
-pub use chunk_config::{ChunkConfig, PagingSpec};
+pub use chunk_config::{ChunkConfig, GcdSpec, FloatMultSpec, PagingSpec};
 pub use chunk_meta::{ChunkLatentMeta, ChunkMeta};
-pub use constants::{DEFAULT_COMPRESSION_LEVEL, FULL_BATCH_SIZE};
+pub use constants::{DEFAULT_COMPRESSION_LEVEL, FULL_BATCH_N};
 pub use modes::Mode;
 
 #[doc = include_str!("../README.md")]

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -21,9 +21,6 @@ pub mod standalone;
 /// for compressing/decompressing as part of an outer, wrapping format
 pub mod wrapped;
 
-// TODO namings to straighten out or reconsider:
-// * src, dst, compressed, bytes, data
-
 mod ans;
 mod auto;
 mod bin;

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -23,8 +23,6 @@ pub mod wrapped;
 
 // TODO namings to straighten out or reconsider:
 // * src, dst, compressed, bytes, data
-// * latent, latent variable
-// * ans vals
 
 mod ans;
 mod auto;

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub use auto::auto_delta_encoding_order;
 pub use bin::Bin;
-pub use chunk_config::{ChunkConfig, GcdSpec, FloatMultSpec, PagingSpec};
+pub use chunk_config::{ChunkConfig, FloatMultSpec, GcdSpec, PagingSpec};
 pub use chunk_meta::{ChunkLatentVarMeta, ChunkMeta};
 pub use constants::{DEFAULT_COMPRESSION_LEVEL, FULL_BATCH_N};
 pub use modes::Mode;
@@ -34,6 +34,7 @@ mod bit_reader;
 mod bit_writer;
 mod bits;
 mod chunk_meta;
+mod compression_intermediates;
 mod compression_table;
 mod constants;
 mod delta;
@@ -43,7 +44,6 @@ mod latent_batch_decompressor;
 mod latent_batch_dissector;
 mod modes;
 mod progress;
-mod compression_intermediates;
 
 mod chunk_config;
 mod page_meta;

--- a/pco/src/lib.rs
+++ b/pco/src/lib.rs
@@ -6,7 +6,7 @@
 pub use auto::auto_delta_encoding_order;
 pub use bin::Bin;
 pub use chunk_config::{ChunkConfig, GcdSpec, FloatMultSpec, PagingSpec};
-pub use chunk_meta::{ChunkLatentMeta, ChunkMeta};
+pub use chunk_meta::{ChunkLatentVarMeta, ChunkMeta};
 pub use constants::{DEFAULT_COMPRESSION_LEVEL, FULL_BATCH_N};
 pub use modes::Mode;
 
@@ -23,7 +23,6 @@ pub mod wrapped;
 
 // TODO namings to straighten out or reconsider:
 // * src, dst, compressed, bytes, data
-// * n, size, count
 // * latent, latent variable
 // * ans vals
 
@@ -44,7 +43,7 @@ mod latent_batch_decompressor;
 mod latent_batch_dissector;
 mod modes;
 mod progress;
-mod unsigned_src_dst;
+mod compression_intermediates;
 
 mod chunk_config;
 mod page_meta;

--- a/pco/src/modes/mode.rs
+++ b/pco/src/modes/mode.rs
@@ -48,14 +48,14 @@ pub enum Mode<U: UnsignedLike> {
 }
 
 impl<U: UnsignedLike> Mode<U> {
-  pub(crate) fn n_latents(&self) -> usize {
+  pub(crate) fn n_latent_vars(&self) -> usize {
     match self {
       Mode::Classic | Mode::Gcd => 1,
       Mode::FloatMult(_) => 2,
     }
   }
 
-  pub(crate) fn latent_delta_order(&self, latent_idx: usize, delta_order: usize) -> usize {
+  pub(crate) fn delta_order_for_latent_var(&self, latent_idx: usize, delta_order: usize) -> usize {
     match (self, latent_idx) {
       (Mode::Classic, 0) | (Mode::Gcd, 0) | (Mode::FloatMult(_), 0) => delta_order,
       (Mode::FloatMult(_), 1) => 0,

--- a/pco/src/page_meta.rs
+++ b/pco/src/page_meta.rs
@@ -3,19 +3,19 @@ use std::io::Write;
 use crate::ans::AnsState;
 use crate::bit_reader::BitReader;
 use crate::bit_writer::BitWriter;
-use crate::constants::{Bitlen, ANS_INTERLEAVING, PAGE_LATENT_META_PADDING};
+use crate::constants::{Bitlen, ANS_INTERLEAVING, PAGE_LATENT_VAR_META_PADDING};
 use crate::data_types::UnsignedLike;
 use crate::delta::DeltaMoments;
 use crate::errors::PcoResult;
 use crate::ChunkMeta;
 
 #[derive(Clone, Debug)]
-pub struct PageLatentMeta<U: UnsignedLike> {
+pub struct PageLatentVarMeta<U: UnsignedLike> {
   pub delta_moments: DeltaMoments<U>,
   pub ans_final_state_idxs: [AnsState; ANS_INTERLEAVING],
 }
 
-impl<U: UnsignedLike> PageLatentMeta<U> {
+impl<U: UnsignedLike> PageLatentVarMeta<U> {
   pub fn write_to<W: Write>(&self, ans_size_log: Bitlen, writer: &mut BitWriter<W>) {
     self.delta_moments.write_to(writer);
 
@@ -30,7 +30,7 @@ impl<U: UnsignedLike> PageLatentMeta<U> {
     delta_order: usize,
     ans_size_log: Bitlen,
   ) -> PcoResult<Self> {
-    reader.ensure_padded(PAGE_LATENT_META_PADDING)?;
+    reader.ensure_padded(PAGE_LATENT_VAR_META_PADDING)?;
     let delta_moments = DeltaMoments::parse_from(reader, delta_order)?;
     let mut ans_final_state_idxs = [0; ANS_INTERLEAVING];
     for state in &mut ans_final_state_idxs {
@@ -50,7 +50,7 @@ impl<U: UnsignedLike> PageLatentMeta<U> {
 // (wrapped mode).
 #[derive(Clone, Debug)]
 pub struct PageMeta<U: UnsignedLike> {
-  pub latents: Vec<PageLatentMeta<U>>,
+  pub per_latent_var: Vec<PageLatentVarMeta<U>>,
 }
 
 impl<U: UnsignedLike> PageMeta<U> {
@@ -60,22 +60,22 @@ impl<U: UnsignedLike> PageMeta<U> {
     writer: &mut BitWriter<W>,
   ) {
     for (latent_idx, ans_size_log) in ans_size_logs.enumerate() {
-      self.latents[latent_idx].write_to(ans_size_log, writer);
+      self.per_latent_var[latent_idx].write_to(ans_size_log, writer);
     }
     writer.finish_byte();
   }
 
   pub fn parse_from(reader: &mut BitReader, chunk_meta: &ChunkMeta<U>) -> PcoResult<Self> {
-    let mut latents = Vec::with_capacity(chunk_meta.latents.len());
-    for (latent_idx, latent_meta) in chunk_meta.latents.iter().enumerate() {
-      latents.push(PageLatentMeta::parse_from(
+    let mut per_latent_var = Vec::with_capacity(chunk_meta.per_latent_var.len());
+    for (latent_idx, chunk_latent_var_meta) in chunk_meta.per_latent_var.iter().enumerate() {
+      per_latent_var.push(PageLatentVarMeta::parse_from(
         reader,
-        chunk_meta.latent_delta_order(latent_idx),
-        latent_meta.ans_size_log,
+        chunk_meta.delta_order_for_latent_var(latent_idx),
+        chunk_latent_var_meta.ans_size_log,
       )?);
     }
     reader.drain_empty_byte("non-zero bits at end of data page metadata")?;
 
-    Ok(Self { latents })
+    Ok(Self { per_latent_var })
   }
 }

--- a/pco/src/standalone/compressor.rs
+++ b/pco/src/standalone/compressor.rs
@@ -112,7 +112,7 @@ impl<U: UnsignedLike> ChunkCompressor<U> {
   pub fn write_chunk<W: Write>(&self, dst: W) -> PcoResult<W> {
     let mut writer = BitWriter::new(dst, STANDALONE_CHUNK_PREAMBLE_PADDING);
     writer.write_aligned_bytes(&[self.dtype_byte])?;
-    let n = self.inner.page_sizes()[0];
+    let n = self.inner.n_per_page()[0];
     writer.write_usize(n - 1, BITS_TO_ENCODE_N_ENTRIES);
 
     writer.flush()?;

--- a/pco/src/standalone/constants.rs
+++ b/pco/src/standalone/constants.rs
@@ -4,11 +4,10 @@ use crate::constants::{Bitlen, OVERSHOOT_PADDING};
 pub const MAGIC_HEADER: [u8; 4] = [112, 99, 111, 33];
 pub const MAGIC_TERMINATION_BYTE: u8 = 0;
 pub const BITS_TO_ENCODE_N_ENTRIES: Bitlen = 24;
-pub const BITS_TO_ENCODE_COMPRESSED_PAGE_SIZE: Bitlen = 32;
 
 // padding
 pub const STANDALONE_CHUNK_PREAMBLE_PADDING: usize =
-  1 + (BITS_TO_ENCODE_N_ENTRIES + BITS_TO_ENCODE_COMPRESSED_PAGE_SIZE) as usize + OVERSHOOT_PADDING;
+  1 + BITS_TO_ENCODE_N_ENTRIES as usize + OVERSHOOT_PADDING;
 
 #[cfg(test)]
 mod tests {

--- a/pco/src/standalone/decompressor.rs
+++ b/pco/src/standalone/decompressor.rs
@@ -11,13 +11,13 @@ use crate::{bit_reader, wrapped, ChunkMeta};
 ///
 /// Example of the lowest level API for reading a .pco file:
 /// ```
-/// use pco::FULL_BATCH_SIZE;
+/// use pco::FULL_BATCH_N;
 /// use pco::standalone::FileDecompressor;
 /// # use pco::errors::PcoResult;
 ///
 /// # fn main() -> PcoResult<()> {
 /// let src = vec![112, 99, 111, 33, 0, 0]; // the minimal .pco file, for the sake of example
-/// let mut nums = vec![0; FULL_BATCH_SIZE];
+/// let mut nums = vec![0; FULL_BATCH_N];
 /// let (file_decompressor, mut byte_idx) = FileDecompressor::new(&src)?;
 /// let mut finished_file = false;
 /// while !finished_file {

--- a/pco/src/standalone/simple.rs
+++ b/pco/src/standalone/simple.rs
@@ -19,12 +19,12 @@ pub fn simple_compress<T: NumberLike>(nums: &[T], config: &ChunkConfig) -> PcoRe
   file_compressor.write_header(&mut dst)?;
 
   // here we use the paging spec to determine chunks; each chunk has 1 page
-  let page_sizes = config.paging_spec.page_sizes(nums.len())?;
+  let n_per_page = config.paging_spec.n_per_page(nums.len())?;
   let mut start = 0;
   let mut this_chunk_config = config.clone();
-  for &page_size in &page_sizes {
-    let end = start + page_size;
-    this_chunk_config.paging_spec = PagingSpec::ExactPageSizes(vec![page_size]);
+  for &page_n in &n_per_page {
+    let end = start + page_n;
+    this_chunk_config.paging_spec = PagingSpec::ExactPageSizes(vec![page_n]);
     let chunk_compressor =
       file_compressor.chunk_compressor(&nums[start..end], &this_chunk_config)?;
     dst.reserve(chunk_compressor.chunk_size_hint());

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -44,8 +44,8 @@ fn test_insufficient_data_short_bins() -> PcoResult<()> {
   }
 
   let meta = assert_panic_safe(nums)?;
-  assert_eq!(meta.latents.len(), 1);
-  assert_eq!(meta.latents[0].bins.len(), 2);
+  assert_eq!(meta.per_latent_var.len(), 1);
+  assert_eq!(meta.per_latent_var[0].bins.len(), 2);
   Ok(())
 }
 
@@ -57,8 +57,8 @@ fn test_insufficient_data_sparse() -> PcoResult<()> {
   }
 
   let meta = assert_panic_safe(nums)?;
-  assert_eq!(meta.latents.len(), 1);
-  assert_eq!(meta.latents[0].bins.len(), 2);
+  assert_eq!(meta.per_latent_var.len(), 1);
+  assert_eq!(meta.per_latent_var[0].bins.len(), 2);
   Ok(())
 }
 
@@ -71,8 +71,8 @@ fn test_insufficient_data_long_offsets() -> PcoResult<()> {
   }
 
   let meta = assert_panic_safe(nums)?;
-  assert_eq!(meta.latents.len(), 1);
-  assert_eq!(meta.latents[0].bins.len(), 1);
-  assert_eq!(meta.latents[0].bins[0].offset_bits, 64);
+  assert_eq!(meta.per_latent_var.len(), 1);
+  assert_eq!(meta.per_latent_var[0].bins.len(), 1);
+  assert_eq!(meta.per_latent_var[0].bins[0].offset_bits, 64);
   Ok(())
 }

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -2,12 +2,13 @@ use crate::chunk_config::ChunkConfig;
 use crate::chunk_meta::ChunkMeta;
 use crate::data_types::NumberLike;
 use crate::errors::{ErrorKind, PcoResult};
+use crate::GcdSpec;
 use crate::standalone::{auto_decompress, FileCompressor};
 
 fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> PcoResult<ChunkMeta<T::Unsigned>> {
   let fc = FileCompressor::default();
   let config = ChunkConfig {
-    use_gcds: false,
+    gcd_spec: GcdSpec::Disabled,
     delta_encoding_order: Some(0),
     ..Default::default()
   };

--- a/pco/src/tests/stability.rs
+++ b/pco/src/tests/stability.rs
@@ -2,8 +2,8 @@ use crate::chunk_config::ChunkConfig;
 use crate::chunk_meta::ChunkMeta;
 use crate::data_types::NumberLike;
 use crate::errors::{ErrorKind, PcoResult};
-use crate::GcdSpec;
 use crate::standalone::{auto_decompress, FileCompressor};
+use crate::GcdSpec;
 
 fn assert_panic_safe<T: NumberLike>(nums: Vec<T>) -> PcoResult<ChunkMeta<T::Unsigned>> {
   let fc = FileCompressor::default();
@@ -73,6 +73,9 @@ fn test_insufficient_data_long_offsets() -> PcoResult<()> {
   let meta = assert_panic_safe(nums)?;
   assert_eq!(meta.per_latent_var.len(), 1);
   assert_eq!(meta.per_latent_var[0].bins.len(), 1);
-  assert_eq!(meta.per_latent_var[0].bins[0].offset_bits, 64);
+  assert_eq!(
+    meta.per_latent_var[0].bins[0].offset_bits,
+    64
+  );
   Ok(())
 }

--- a/pco/src/wrapped/chunk_compressor.rs
+++ b/pco/src/wrapped/chunk_compressor.rs
@@ -490,12 +490,12 @@ impl<U: UnsignedLike> ChunkCompressor<U> {
   /// This can be useful when building the file as a `Vec<u8>` in memory;
   /// you can `.reserve()` ahead of time.
   pub fn chunk_meta_size_hint(&self) -> usize {
-    let mut bytes = 32;
+    let mut size = 32;
     let bytes_per_num = U::BITS / 8;
     for latent_meta in &self.meta.per_latent_var {
-      bytes += latent_meta.bins.len() * (4 + 2 * bytes_per_num as usize)
+      size += latent_meta.bins.len() * (4 + 2 * bytes_per_num as usize)
     }
-    bytes
+    size
   }
 
   /// Writes the chunk metadata to the destination.

--- a/pco/src/wrapped/chunk_decompressor.rs
+++ b/pco/src/wrapped/chunk_decompressor.rs
@@ -1,5 +1,5 @@
 use crate::bit_reader::BitReader;
-use crate::constants::PAGE_LATENT_META_PADDING;
+use crate::constants::PAGE_LATENT_VAR_META_PADDING;
 use crate::data_types::NumberLike;
 use crate::errors::PcoResult;
 use crate::page_meta::PageMeta;
@@ -29,7 +29,7 @@ impl<T: NumberLike> ChunkDecompressor<T> {
   ///
   /// Will return an error if corruptions or insufficient data are found.
   pub fn page_decompressor(&self, n: usize, src: &[u8]) -> PcoResult<(PageDecompressor<T>, usize)> {
-    let extension = bit_reader::make_extension_for(src, PAGE_LATENT_META_PADDING);
+    let extension = bit_reader::make_extension_for(src, PAGE_LATENT_VAR_META_PADDING);
     let mut reader = BitReader::new(src, &extension);
     let page_meta = PageMeta::<T::Unsigned>::parse_from(&mut reader, &self.meta)?;
     let pd = PageDecompressor::new(self, n, page_meta, reader.bits_past_byte % 8)?;

--- a/pco/src/wrapped/file_compressor.rs
+++ b/pco/src/wrapped/file_compressor.rs
@@ -29,7 +29,7 @@ use crate::ChunkConfig;
 ///     &ChunkConfig::default(),
 ///   )?;
 ///   chunk_compressor.write_chunk_meta(&mut compressed)?;
-///   for page_idx in 0..chunk_compressor.page_sizes().len() {
+///   for page_idx in 0..chunk_compressor.n_per_page().len() {
 ///     // probably write more custom stuff here
 ///     chunk_compressor.write_page(page_idx, &mut compressed)?;
 ///   }

--- a/pco_cli/src/compress_handler.rs
+++ b/pco_cli/src/compress_handler.rs
@@ -37,7 +37,11 @@ impl<P: NumberLikeArrow> CompressHandler for HandlerImpl<P> {
     let config = ChunkConfig::default()
       .with_compression_level(opt.level)
       .with_delta_encoding_order(opt.delta_encoding_order)
-      .with_gcd_spec(if opt.disable_gcds { GcdSpec::Disabled } else { GcdSpec::Enabled });
+      .with_gcd_spec(if opt.disable_gcds {
+        GcdSpec::Disabled
+      } else {
+        GcdSpec::Enabled
+      });
     let fc = FileCompressor::default();
     fc.write_header(&file)?;
 

--- a/pco_cli/src/compress_handler.rs
+++ b/pco_cli/src/compress_handler.rs
@@ -11,7 +11,7 @@ use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchR
 use parquet::arrow::ProjectionMask;
 
 use pco::standalone::FileCompressor;
-use pco::ChunkConfig;
+use pco::{ChunkConfig, GcdSpec};
 
 use crate::handlers::HandlerImpl;
 use crate::number_like_arrow::NumberLikeArrow;
@@ -37,7 +37,7 @@ impl<P: NumberLikeArrow> CompressHandler for HandlerImpl<P> {
     let config = ChunkConfig::default()
       .with_compression_level(opt.level)
       .with_delta_encoding_order(opt.delta_encoding_order)
-      .with_use_gcds(!opt.disable_gcds);
+      .with_gcd_spec(if opt.disable_gcds { GcdSpec::Disabled } else { GcdSpec::Enabled });
     let fc = FileCompressor::default();
     fc.write_header(&file)?;
 

--- a/pco_cli/src/decompress_handler.rs
+++ b/pco_cli/src/decompress_handler.rs
@@ -7,7 +7,7 @@ use arrow::array::PrimitiveArray;
 use arrow::csv::WriterBuilder as CsvWriterBuilder;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
-use pco::FULL_BATCH_SIZE;
+use pco::FULL_BATCH_N;
 
 use pco::standalone::FileDecompressor;
 
@@ -39,7 +39,7 @@ impl<P: NumberLikeArrow> DecompressHandler for HandlerImpl<P> {
         let n = cd.n();
         let batch_size = min(n, remaining_limit);
         // how many pco should decompress
-        let pco_size = (1 + batch_size / FULL_BATCH_SIZE) * FULL_BATCH_SIZE;
+        let pco_size = (1 + batch_size / FULL_BATCH_N) * FULL_BATCH_N;
         nums.resize(pco_size, P::Num::default());
         let (_, additional) = cd.decompress(&bytes[consumed..], &mut nums)?;
         consumed += additional;

--- a/pco_cli/src/inspect_handler.rs
+++ b/pco_cli/src/inspect_handler.rs
@@ -114,7 +114,7 @@ impl<P: NumberLikeArrow> InspectHandler for HandlerImpl<P> {
         "\nchunk: {} n: {} delta order: {} mode: {:?}",
         i, chunk_ns[i], meta.delta_encoding_order, meta.mode,
       );
-      for (latent_idx, latent) in meta.latents.iter().enumerate() {
+      for (latent_idx, latent) in meta.per_latent_var.iter().enumerate() {
         let latent_name = match (meta.mode, latent_idx) {
           (Mode::Classic, 0) => "primary".to_string(),
           (Mode::Gcd, 0) => "primary".to_string(),


### PR DESCRIPTION
* "size" for bytes, "count" and "n" for # of numbers
* disambiguated between "latent" and "latent var"
* "ans val" instead of "state offset"
* "compressed" instead of "bytes"
* also switched GCD and float configs to extensible enums instead of just bools
* generally use "per_foo" instead of just "foo" for a Vec with one element per foo