### PR TITLE
Prefixed exposed names with pco

### DIFF
--- a/pco_c/include/cpcodec.h
+++ b/pco_c/include/cpcodec.h
@@ -1,3 +1,7 @@
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
 #include "cpcodec_generated.h"
 
 // cbindgen can only handle literal constants, which isn't helpful when these
@@ -8,3 +12,7 @@
 #define PCO_TYPE_I64 4
 #define PCO_TYPE_F32 5
 #define PCO_TYPE_F64 6
+
+#if defined (__cplusplus)
+}
+#endif

--- a/pco_c/include/cpcodec_generated.h
+++ b/pco_c/include/cpcodec_generated.h
@@ -1,7 +1,8 @@
 typedef enum PcoError {
-  Success,
-  InvalidType,
-  DecompressionError,
+  PcoSuccess,
+  PcoInvalidType,
+  PcoCompressionError,
+  PcoDecompressionError,
 } PcoError;
 
 typedef struct PcoFfiVec {
@@ -10,15 +11,15 @@ typedef struct PcoFfiVec {
   const void *raw_box;
 } PcoFfiVec;
 
-enum PcoError auto_compress(const void *nums,
-                            unsigned int len,
-                            unsigned char dtype,
-                            unsigned int level,
-                            struct PcoFfiVec *dst);
+enum PcoError pco_auto_compress(const void *nums,
+                                unsigned int len,
+                                unsigned char dtype,
+                                unsigned int level,
+                                struct PcoFfiVec *dst);
 
-enum PcoError auto_decompress(const void *compressed,
-                              unsigned int len,
-                              unsigned char dtype,
-                              struct PcoFfiVec *dst);
+enum PcoError pco_auto_decompress(const void *compressed,
+                                  unsigned int len,
+                                  unsigned char dtype,
+                                  struct PcoFfiVec *dst);
 
-enum PcoError free_pcovec(struct PcoFfiVec *ffi_vec);
+enum PcoError pco_free_pcovec(struct PcoFfiVec *ffi_vec);

--- a/pco_c/src/lib.rs
+++ b/pco_c/src/lib.rs
@@ -6,15 +6,15 @@ use libc::{c_uchar, c_uint, c_void};
 
 use pco::data_types::{CoreDataType, NumberLike};
 
-use crate::PcoError::InvalidType;
+use crate::PcoError::PcoInvalidType;
 
 #[repr(C)]
 pub enum PcoError {
-  Success,
-  InvalidType,
+  PcoSuccess,
+  PcoInvalidType,
   // TODO split this into the actual error kinds
-  CompressionError,
-  DecompressionError,
+  PcoCompressionError,
+  PcoDecompressionError,
 }
 
 macro_rules! impl_dtypes {
@@ -90,10 +90,10 @@ fn _simpler_compress<T: NumberLike>(
 ) -> PcoError {
   let slice = unsafe { std::slice::from_raw_parts(nums as *const T, len as usize) };
   match pco::standalone::simpler_compress(slice, level as usize) {
-    Err(_) => PcoError::CompressionError,
+    Err(_) => PcoError::PcoCompressionError,
     Ok(v) => {
       unsafe { (*ffi_vec_ptr).init_from_vec(v) };
-      PcoError::Success
+      PcoError::PcoSuccess
     }
   }
 }
@@ -108,17 +108,17 @@ where
 {
   let slice = unsafe { std::slice::from_raw_parts(compressed as *const u8, len as usize) };
   match pco::standalone::simple_decompress::<T>(slice) {
-    Err(_) => PcoError::DecompressionError,
+    Err(_) => PcoError::PcoDecompressionError,
     Ok(v) => {
       unsafe { (*ffi_vec_ptr).init_from_vec(v) };
-      PcoError::Success
+      PcoError::PcoSuccess
     }
   }
 }
 
 // TODO rename this simple[r] instead of auto
 #[no_mangle]
-pub extern "C" fn auto_compress(
+pub extern "C" fn pco_auto_compress(
   nums: *const c_void,
   len: c_uint,
   dtype: c_uchar,
@@ -126,7 +126,7 @@ pub extern "C" fn auto_compress(
   dst: *mut PcoFfiVec,
 ) -> PcoError {
   let Some(dtype) = CoreDataType::from_byte(dtype) else {
-    return InvalidType;
+    return PcoInvalidType;
   };
 
   match_dtype!(
@@ -137,14 +137,14 @@ pub extern "C" fn auto_compress(
 }
 
 #[no_mangle]
-pub extern "C" fn auto_decompress(
+pub extern "C" fn pco_auto_decompress(
   compressed: *const c_void,
   len: c_uint,
   dtype: c_uchar,
   dst: *mut PcoFfiVec,
 ) -> PcoError {
   let Some(dtype) = CoreDataType::from_byte(dtype) else {
-    return InvalidType;
+    return PcoInvalidType;
   };
 
   match_dtype!(
@@ -155,7 +155,7 @@ pub extern "C" fn auto_decompress(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free_pcovec(ffi_vec: *mut PcoFfiVec) -> PcoError {
+pub unsafe extern "C" fn pco_free_pcovec(ffi_vec: *mut PcoFfiVec) -> PcoError {
   unsafe { (*ffi_vec).free() };
-  PcoError::Success
+  PcoError::PcoSuccess
 }

--- a/pco_c/test/test_cpcodec.c
+++ b/pco_c/test/test_cpcodec.c
@@ -11,8 +11,8 @@ int main() {
   int retcode = 0;
 
   struct PcoFfiVec cvec;
-  enum PcoError res = auto_compress(&input, num_elems, PCO_TYPE_F32, 8, &cvec);
-  if (res != Success) {
+  enum PcoError res = pco_auto_compress(&input, num_elems, PCO_TYPE_F32, 8, &cvec);
+  if (res != PcoSuccess) {
     printf("Error compressing: %d\n", res);
     retcode = 1;
     goto cleanup_none;
@@ -20,10 +20,10 @@ int main() {
   printf("Compressed %d floats to %d bytes\n", num_elems, cvec.len);
 
   struct PcoFfiVec dvec;
-  res = auto_decompress(cvec.ptr, cvec.len, PCO_TYPE_F32, &dvec);
-  if (res != Success) {
+  res = pco_auto_decompress(cvec.ptr, cvec.len, PCO_TYPE_F32, &dvec);
+  if (res != PcoSuccess) {
     printf("Error decompressing: %d\n", res);
-    free_pcovec(&cvec);
+    pco_free_pcovec(&cvec);
     retcode = 1;
     goto cleanup_cvec;
   }
@@ -44,13 +44,13 @@ int main() {
   printf("Values match\n");
 
 cleanup_all:
-  free_pcovec(&dvec);
+  pco_free_pcovec(&dvec);
   if (!is_empty(&dvec)) {
     printf("Decompression vector not freed!!!\n");
     retcode = 1;
   }
 cleanup_cvec:
-  free_pcovec(&cvec);
+  pco_free_pcovec(&cvec);
   if (!is_empty(&cvec)) {
     printf("Compression vector not freed!!!\n");
     retcode = 1;


### PR DESCRIPTION
Prefixed the names exposed to C with `pco_`

This is what most other c libraries do and is important since there's no proper namespacing there.

I also added a preprocessor branch to work better with C++