### PR TITLE
Release CPython GIL using `allow_threads`

### DIFF
--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -13,10 +13,13 @@ pub mod wrapped;
 
 pub fn core_dtype_from_str(s: &str) -> PyResult<CoreDataType> {
   match s.to_uppercase().as_str() {
+    "F16" => Ok(CoreDataType::F16),
     "F32" => Ok(CoreDataType::F32),
     "F64" => Ok(CoreDataType::F64),
+    "I16" => Ok(CoreDataType::I16),
     "I32" => Ok(CoreDataType::I32),
     "I64" => Ok(CoreDataType::I64),
+    "U16" => Ok(CoreDataType::U16),
     "U32" => Ok(CoreDataType::U32),
     "U64" => Ok(CoreDataType::U64),
     _ => Err(PyRuntimeError::new_err(format!(

--- a/pco_python/src/standalone.rs
+++ b/pco_python/src/standalone.rs
@@ -6,6 +6,7 @@ use pyo3::types::{PyBytes, PyModule, PyNone};
 use pyo3::{pyfunction, wrap_pyfunction, PyObject, PyResult, Python};
 
 use pco::data_types::NumberLike;
+use pco::errors::PcoResult;
 use pco::standalone::{FileDecompressor, MaybeChunkDecompressor};
 use pco::{standalone, with_core_dtypes, ChunkConfig};
 
@@ -16,23 +17,25 @@ fn decompress_chunks<'py, T: NumberLike + Element>(
   mut src: &[u8],
   file_decompressor: FileDecompressor,
 ) -> PyResult<&'py PyArray1<T>> {
-  let n_hint = file_decompressor.n_hint();
-  let mut res: Vec<T> = Vec::with_capacity(n_hint);
-  while let MaybeChunkDecompressor::Some(mut chunk_decompressor) = file_decompressor
-    .chunk_decompressor::<T, &[u8]>(src)
-    .map_err(pco_err_to_py)?
-  {
-    let initial_len = res.len(); // probably always zero to start, since we just created res
-    let remaining = chunk_decompressor.n();
-    unsafe {
-      res.set_len(initial_len + remaining);
-    }
-    let progress = chunk_decompressor
-      .decompress(&mut res[initial_len..])
-      .map_err(pco_err_to_py)?;
-    assert!(progress.finished);
-    src = chunk_decompressor.into_src();
-  }
+  let res = py
+    .allow_threads(|| -> PcoResult<Vec<T>> {
+      let n_hint = file_decompressor.n_hint();
+      let mut res: Vec<T> = Vec::with_capacity(n_hint);
+      while let MaybeChunkDecompressor::Some(mut chunk_decompressor) =
+        file_decompressor.chunk_decompressor::<T, &[u8]>(src)?
+      {
+        let initial_len = res.len(); // probably always zero to start, since we just created res
+        let remaining = chunk_decompressor.n();
+        unsafe {
+          res.set_len(initial_len + remaining);
+        }
+        let progress = chunk_decompressor.decompress(&mut res[initial_len..])?;
+        assert!(progress.finished);
+        src = chunk_decompressor.into_src();
+      }
+      Ok(res)
+    })
+    .map_err(pco_err_to_py)?;
   let py_array = res.into_pyarray(py);
   Ok(py_array)
 }
@@ -44,20 +47,25 @@ fn simple_compress_generic<'py, T: NumberLike + Element>(
 ) -> PyResult<PyObject> {
   let arr_ro = arr.readonly();
   let src = arr_ro.as_slice()?;
-  let compressed = standalone::simple_compress(src, config).map_err(pco_err_to_py)?;
+  let compressed = py
+    .allow_threads(|| standalone::simple_compress(src, config))
+    .map_err(pco_err_to_py)?;
   // TODO apparently all the places we use PyBytes::new() copy the data.
   // Maybe there's a zero-copy way to do this.
   Ok(PyBytes::new(py, &compressed).into())
 }
 
-fn simple_decompress_into_generic<T: NumberLike + Element>(
+fn simple_decompress_into_generic<'py, T: NumberLike + Element>(
+  py: Python<'py>,
   compressed: &PyBytes,
   arr: &PyArrayDyn<T>,
 ) -> PyResult<PyProgress> {
   let mut out_rw = arr.readwrite();
   let dst = out_rw.as_slice_mut()?;
   let src = compressed.as_bytes();
-  let progress = standalone::simple_decompress_into(src, dst).map_err(pco_err_to_py)?;
+  let progress = py
+    .allow_threads(|| standalone::simple_decompress_into(src, dst))
+    .map_err(pco_err_to_py)?;
   Ok(PyProgress::from(progress))
 }
 
@@ -105,11 +113,15 @@ pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
   ///
   /// :raises: TypeError, RuntimeError
   #[pyfunction]
-  fn simple_decompress_into(compressed: &PyBytes, dst: DynTypedPyArrayDyn) -> PyResult<PyProgress> {
+  fn simple_decompress_into<'py>(
+    py: Python<'py>,
+    compressed: &PyBytes,
+    dst: DynTypedPyArrayDyn,
+  ) -> PyResult<PyProgress> {
     macro_rules! match_py_array {
       {$($name:ident($lname:ident) => $t:ty,)+} => {
         match dst {
-          $(DynTypedPyArrayDyn::$name(arr) => simple_decompress_into_generic(compressed, arr),)+
+          $(DynTypedPyArrayDyn::$name(arr) => simple_decompress_into_generic(py, compressed, arr),)+
         }
       }
     }

--- a/pco_python/src/standalone.rs
+++ b/pco_python/src/standalone.rs
@@ -55,8 +55,8 @@ fn simple_compress_generic<'py, T: NumberLike + Element>(
   Ok(PyBytes::new(py, &compressed).into())
 }
 
-fn simple_decompress_into_generic<'py, T: NumberLike + Element>(
-  py: Python<'py>,
+fn simple_decompress_into_generic<T: NumberLike + Element>(
+  py: Python,
   compressed: &PyBytes,
   arr: &PyArrayDyn<T>,
 ) -> PyResult<PyProgress> {
@@ -113,8 +113,8 @@ pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
   ///
   /// :raises: TypeError, RuntimeError
   #[pyfunction]
-  fn simple_decompress_into<'py>(
-    py: Python<'py>,
+  fn simple_decompress_into(
+    py: Python,
     compressed: &PyBytes,
     dst: DynTypedPyArrayDyn,
   ) -> PyResult<PyProgress> {

--- a/pco_python/src/standalone.rs
+++ b/pco_python/src/standalone.rs
@@ -6,7 +6,6 @@ use pyo3::types::{PyBytes, PyModule, PyNone};
 use pyo3::{pyfunction, wrap_pyfunction, PyObject, PyResult, Python};
 
 use pco::data_types::NumberLike;
-use pco::errors::PcoResult;
 use pco::standalone::{FileDecompressor, MaybeChunkDecompressor};
 use pco::{standalone, with_core_dtypes, ChunkConfig};
 
@@ -18,7 +17,7 @@ fn decompress_chunks<'py, T: NumberLike + Element>(
   file_decompressor: FileDecompressor,
 ) -> PyResult<&'py PyArray1<T>> {
   let res = py
-    .allow_threads(|| -> PcoResult<Vec<T>> {
+    .allow_threads(|| {
       let n_hint = file_decompressor.n_hint();
       let mut res: Vec<T> = Vec::with_capacity(n_hint);
       while let MaybeChunkDecompressor::Some(mut chunk_decompressor) =

--- a/pco_python/src/wrapped/decompressor.rs
+++ b/pco_python/src/wrapped/decompressor.rs
@@ -118,9 +118,11 @@ impl PyCd {
           $((DynCd::$name(cd), DynTypedPyArrayDyn::$name(arr)) => {
             let mut arr_rw = arr.readwrite();
             let dst = arr_rw.as_slice_mut()?;
-            let mut pd = py.allow_threads(|| cd.page_decompressor(src, page_n)).map_err(pco_err_to_py)?;
-            let progress = py.allow_threads(|| pd.decompress(dst)).map_err(pco_err_to_py)?;
-            (progress, pd.into_src())
+            py.allow_threads(|| {
+              let mut pd = cd.page_decompressor(src, page_n)?;
+              let progress = pd.decompress(dst)?;
+              Ok((progress, pd.into_src()))
+            }).map_err(pco_err_to_py)?
           })+
           _ => {
             return Err(PyRuntimeError::new_err(format!(

--- a/pco_python/src/wrapped/decompressor.rs
+++ b/pco_python/src/wrapped/decompressor.rs
@@ -67,7 +67,7 @@ impl PyFd {
         match dtype {
           $(CoreDataType::$name => {
             let (generic_cd, rest) = inner
-                .chunk_decompressor::<$t, _>(src)
+              .chunk_decompressor::<$t, _>(src)
               .map_err(pco_err_to_py)?;
             (DynCd::$name(generic_cd), rest)
           })+

--- a/pco_python/test/test_standalone.py
+++ b/pco_python/test/test_standalone.py
@@ -10,7 +10,7 @@ all_shapes = (
   [9, 100],
 )
 
-all_dtypes = ('f4', 'f8', 'i4', 'i8', 'u4', 'u8')
+all_dtypes = ('f2', 'f4', 'f8', 'i2', 'i4', 'i8', 'u2', 'u4', 'u8')
 
 @pytest.mark.parametrize("shape", all_shapes)
 @pytest.mark.parametrize("dtype", all_dtypes)

--- a/pco_python/test/test_wrapped.py
+++ b/pco_python/test/test_wrapped.py
@@ -4,7 +4,7 @@ from pcodec.wrapped import FileCompressor, FileDecompressor
 import pytest
 
 np.random.seed(12345)
-all_dtypes = ('f4', 'f8', 'i4', 'i8', 'u4', 'u8')
+all_dtypes = ('f2', 'f4', 'f8', 'i2', 'i4', 'i8', 'u2', 'u4', 'u8')
 
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_compress(dtype):


### PR DESCRIPTION
# Background
The notorious CPython GIL prevents threaded true parallelism in Python code. External code may choose to release the GIL to allow threaded parallelism for specific sections of the code. This can provide huge performance benefits in cases where most of the work can safely be done outside of Python. A common example is a Python web server, where threads are often used for async operations, but will also benefit performance when work can be performed outside the GIL.

# Tasks done
- [x] Implement `allow_threads` in `standalone`
- [x] Implement `allow_threads` in `wrapped`
- [x] `cargo fmt`
- [x] `cargo test`
- [x] `cargo clippy`
- [x] `pytest` 
- [x] `maturin build --release --out dist --manifest-path pco_python/Cargo.toml`

# Benchmarks
``` python
iterations = 10

dur = 0
for i in range(iterations):
    com_f16_frames = []
    start = time()
    com_f16_frames = [standalone.simple_compress(f, config) for f in in_f16]
    dur += (time() - start) / iterations
print(f"{len(com_f16_frames) / dur:.0f} FPS")
print(f"{in_f16.nbytes / dur / 1000**2:.0f} MB/s")
# 1236 FPS
# 127 MB/s

dur = 0
with ThreadPool(4) as pool:
    for i in range(iterations):
        com_f16_frames = []
        start = time()
        com_f16_frames = pool.map(lambda f: standalone.simple_compress(f, config), in_f16)
        dur += (time() - start) / iterations
print(f"{len(com_f16_frames) / dur:.0f} FPS")
print(f"{in_f16.nbytes / dur / 1000**2:.0f} MB/s")
# 4635 FPS
# 478 MB/s

dur = 0
for i in range(iterations):
    decom_f16_frames = []
    start = time()
    decom_f16_frames = [standalone.simple_decompress(f) for f in com_f16_frames]
    dur += (time() - start) / iterations
print(f"{len(com_f16_frames) / dur:.0f} FPS")
print(f"{in_f16.nbytes / dur / 1000**2:.0f} MB/s")
# 8773 FPS
# 904 MB/s

dur = 0
with ThreadPool(4) as pool:
    for i in range(iterations):
        decom_f16_frames = []
        start = time()
        decom_f16_frames = pool.map(standalone.simple_decompress, com_f16_frames)
        dur += (time() - start) / iterations
print(f"{len(com_f16_frames) / dur:.0f} FPS")
print(f"{in_f16.nbytes / dur / 1000**2:.0f} MB/s")
# 30513 FPS
# 3144 MB/s
```