### PR TITLE
Added missing options to `PyChunkConfig`, fixes #202

### DIFF
--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -167,11 +167,11 @@ impl PyChunkConfig {
   ///
   /// :param compression_level: a compression level from 0-12, where 12 takes
   /// the longest and compresses the most.
-  /// 
+  ///
   /// :param delta_encoding_order: either a delta encoding level from 0-7 or
   /// None. If set to None, pcodec will try to infer the optimal delta encoding
   /// order.
-  /// 
+  ///
   /// :param int_mult_spec: a IntMultSpec that configures whether integer
   /// multiplier detection is enabled.
   ///
@@ -184,7 +184,7 @@ impl PyChunkConfig {
   /// substantially reduced. This configuration may hurt
   /// compression speed slightly even when it isn't helpful.
   /// However, the compression ratio improvements tend to be large.
-  /// 
+  ///
   /// :param float_mult_spec: a FloatMultSpec that configures whether float
   /// multiplier detection is enabled.
   ///
@@ -197,14 +197,14 @@ impl PyChunkConfig {
   /// substantially reduced. In rare cases, this configuration
   /// may reduce compression speed somewhat even when it isn't helpful.
   /// However, the compression ratio improvements tend to be large.
-  /// 
+  ///
   /// :param float_quant_spec: a FloatQuantSpec that configures whether
   /// quantized-float detection is enabled.
   ///
   /// Examples where this helps:
   /// * float-valued data stored in a type that is unnecessarily wide (e.g.
   /// stored as `f64`s where only a `f32` worth of precision is used)
-  /// 
+  ///
   /// :param paging_spec: a PagingSpec describing how many numbers should
   /// go into each page.
   ///

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -54,24 +54,24 @@ pub fn pco_err_to_py(pco: PcoError) -> PyErr {
 #[derive(Clone, Default)]
 pub struct PyIntMultSpec(IntMultSpec);
 
-/// Specifies how pcodec should handle modulo compression for integer types.
+/// Specifies if pcodec should use an integer multiplier to compress data.
 #[pymethods]
 impl PyIntMultSpec {
-  /// :returns: a IntMultSpec disabling modulo compression.
+  /// :returns: a IntMultSpec disabling integer multiplier detection.
   #[staticmethod]
   fn disabled() -> Self {
     Self(IntMultSpec::Disabled)
   }
 
-  /// :returns: a IntMultSpec enabling modulo compression. This will
-  /// automatically try to detect whether to use the mode and which `base` to
-  /// use.
+  /// :returns: a IntMultSpec enabling integer multiplier detection. This
+  /// will automatically try to detect whether to use the mode and which `base`
+  /// to use.
   #[staticmethod]
   fn enabled() -> Self {
     Self(IntMultSpec::Enabled)
   }
 
-  /// :returns: a IntMultSpec with a specific `base` for modulo compression.
+  /// :returns: a IntMultSpec with a specific `base` to use for compression.
   #[staticmethod]
   fn provided(base: u64) -> Self {
     Self(IntMultSpec::Provided(base))
@@ -82,25 +82,25 @@ impl PyIntMultSpec {
 #[derive(Clone, Default)]
 pub struct PyFloatMultSpec(FloatMultSpec);
 
-/// Specifies how pcodec should handle floating point multiplication
-/// compression.
+/// Specifies if pcodec should use a floating point multiplier to compress
+/// data.
 #[pymethods]
 impl PyFloatMultSpec {
-  /// :returns: a FloatMultSpec disabling floating point multiplication.
+  /// :returns: a FloatMultSpec disabling floating point multiplier detection.
   #[staticmethod]
   fn disabled() -> Self {
     Self(FloatMultSpec::Disabled)
   }
 
-  /// :returns: a FloatMultSpec enabling floating point multiplication. This
-  /// will automatically try to detect whether to use the mode and which `base`
-  /// to use.
+  /// :returns: a FloatMultSpec enabling floating point multiplier detection.
+  /// This will automatically try to detect whether to use the mode and which
+  /// `base` to use.
   #[staticmethod]
   fn enabled() -> Self {
     Self(FloatMultSpec::Enabled)
   }
 
-  /// :returns: a FloatMultSpec with a specific `base` for floating point
+  /// :returns: a FloatMultSpec with a specific `base` to use for compression.
   #[staticmethod]
   fn provided(base: f64) -> Self {
     Self(FloatMultSpec::Provided(base))
@@ -111,7 +111,8 @@ impl PyFloatMultSpec {
 #[derive(Clone, Default)]
 pub struct PyFloatQuantSpec(FloatQuantSpec);
 
-/// Specifies how pcodec should handle floating point quantization compression.
+/// Specifies if pcodec should use floating point quantization to compress
+/// data.
 #[pymethods]
 impl PyFloatQuantSpec {
   /// :returns: a FloatQuantSpec disabling floating point quantization.
@@ -120,7 +121,8 @@ impl PyFloatQuantSpec {
     Self(FloatQuantSpec::Disabled)
   }
 
-  /// :returns: a FloatQuantSpec with a specific `bits` for floating point
+  /// :returns: a FloatQuantSpec specifying that pcodec should use quantization
+  /// with a specific number of `bits``.
   #[staticmethod]
   fn provided(bits: u32) -> Self {
     Self(FloatQuantSpec::Provided(bits))

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -54,22 +54,22 @@ pub fn pco_err_to_py(pco: PcoError) -> PyErr {
 #[derive(Clone, Default)]
 pub struct PyIntMultSpec(IntMultSpec);
 
-/// TODO
+/// Specifies how pcodec should handle modulo compression for integer types.
 #[pymethods]
 impl PyIntMultSpec {
-  /// :returns: TODO
+  /// :returns: a IntMultSpec disabling modulo compression.
   #[staticmethod]
   fn disabled() -> Self {
     Self(IntMultSpec::Disabled)
   }
 
-  /// :returns: TODO
+  /// :returns: a IntMultSpec enabling modulo compression.
   #[staticmethod]
   fn enabled() -> Self {
     Self(IntMultSpec::Enabled)
   }
 
-  /// :returns: TODO
+  /// :returns: a IntMultSpec with a specific `base` for modulo compression.
   #[staticmethod]
   fn provided(base: u64) -> Self {
     Self(IntMultSpec::Provided(base))
@@ -80,22 +80,23 @@ impl PyIntMultSpec {
 #[derive(Clone, Default)]
 pub struct PyFloatMultSpec(FloatMultSpec);
 
-/// TODO
+/// Specifies how pcodec should handle floating point multiplication
+/// compression.
 #[pymethods]
 impl PyFloatMultSpec {
-  /// :returns: TODO
+  /// :returns: a FloatMultSpec disabling floating point multiplication.
   #[staticmethod]
   fn disabled() -> Self {
     Self(FloatMultSpec::Disabled)
   }
 
-  /// :returns: TODO
+  /// :returns: a FloatMultSpec enabling floating point multiplication.
   #[staticmethod]
   fn enabled() -> Self {
     Self(FloatMultSpec::Enabled)
   }
 
-  /// :returns: TODO
+  /// :returns: a FloatMultSpec with a specific `base` for floating point
   #[staticmethod]
   fn provided(base: f64) -> Self {
     Self(FloatMultSpec::Provided(base))
@@ -106,16 +107,16 @@ impl PyFloatMultSpec {
 #[derive(Clone, Default)]
 pub struct PyFloatQuantSpec(FloatQuantSpec);
 
-/// TODO
+/// Specifies how pcodec should handle floating point quantization compression.
 #[pymethods]
 impl PyFloatQuantSpec {
-  /// :returns: TODO
+  /// :returns: a FloatQuantSpec disabling floating point quantization.
   #[staticmethod]
   fn disabled() -> Self {
     Self(FloatQuantSpec::Disabled)
   }
 
-  /// :returns: TODO
+  /// :returns: a FloatQuantSpec with a specific `bits` for floating point
   #[staticmethod]
   fn provided(bits: u32) -> Self {
     Self(FloatQuantSpec::Provided(bits))
@@ -165,9 +166,21 @@ impl PyChunkConfig {
   /// :param delta_encoding_order: either a delta encoding level from 0-7 or
   /// None. If set to None, pcodec will try to infer the optimal delta encoding
   /// order.
-  /// :param int_mult_spec: TODO
-  /// :param float_mult_spec: TODO
-  /// :param float_quant_spec: TODO
+  /// :param int_mult_spec: a IntMultSpec disabling, enabling, or providing a
+  /// base for modulo compression. If enabled, pcodec will consider using int
+  /// mult mode, which can substantially improve compression ratio but decrease
+  /// speed in some cases for integer types. If a base is provided, pcodec will
+  /// use that base for modulo compression. Enabled by default.
+  /// :param float_mult_spec: a FloatMultSpec disabling, enabling, or providing
+  /// a base for floating point multiplication compression. If enabled,
+  /// pcodec will consider using float mult mode, which can substantially
+  /// improve compression ratio but decrease speed in some cases for floating
+  /// point types. If a base is provided, pcodec will use that base for
+  /// floating point multiplication compression. Enabled by default.
+  /// :param float_quant_spec: a FloatQuantSpec disabling or providing the
+  /// `bits` for floating point quantization compression. If provided, pcodec
+  /// will use that number of bits for floating point quantization compression.
+  /// To use quantization, float mult must be disabled. Disabled by default.
   /// :param paging_spec: a PagingSpec describing how many numbers should
   /// go into each page.
   ///

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -63,7 +63,9 @@ impl PyIntMultSpec {
     Self(IntMultSpec::Disabled)
   }
 
-  /// :returns: a IntMultSpec enabling modulo compression.
+  /// :returns: a IntMultSpec enabling modulo compression. This will
+  /// automatically try to detect whether to use the mode and which `base` to
+  /// use.
   #[staticmethod]
   fn enabled() -> Self {
     Self(IntMultSpec::Enabled)
@@ -90,7 +92,9 @@ impl PyFloatMultSpec {
     Self(FloatMultSpec::Disabled)
   }
 
-  /// :returns: a FloatMultSpec enabling floating point multiplication.
+  /// :returns: a FloatMultSpec enabling floating point multiplication. This
+  /// will automatically try to detect whether to use the mode and which `base`
+  /// to use.
   #[staticmethod]
   fn enabled() -> Self {
     Self(FloatMultSpec::Enabled)

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -207,9 +207,9 @@ impl TryFrom<&PyChunkConfig> for ChunkConfig {
     let res = ChunkConfig::default()
       .with_compression_level(py_config.compression_level)
       .with_delta_encoding_order(py_config.delta_encoding_order)
-      .with_int_mult_spec(py_config.int_mult_spec.0.clone())
-      .with_float_mult_spec(py_config.float_mult_spec.0.clone())
-      .with_float_quant_spec(py_config.float_quant_spec.0.clone())
+      .with_int_mult_spec(py_config.int_mult_spec.0)
+      .with_float_mult_spec(py_config.float_mult_spec.0)
+      .with_float_quant_spec(py_config.float_quant_spec.0)
       .with_paging_spec(py_config.paging_spec.0.clone());
     Ok(res)
   }

--- a/pco_python/src/lib.rs
+++ b/pco_python/src/lib.rs
@@ -167,24 +167,44 @@ impl PyChunkConfig {
   ///
   /// :param compression_level: a compression level from 0-12, where 12 takes
   /// the longest and compresses the most.
+  /// 
   /// :param delta_encoding_order: either a delta encoding level from 0-7 or
   /// None. If set to None, pcodec will try to infer the optimal delta encoding
   /// order.
-  /// :param int_mult_spec: a IntMultSpec disabling, enabling, or providing a
-  /// base for modulo compression. If enabled, pcodec will consider using int
-  /// mult mode, which can substantially improve compression ratio but decrease
-  /// speed in some cases for integer types. If a base is provided, pcodec will
-  /// use that base for modulo compression. Enabled by default.
-  /// :param float_mult_spec: a FloatMultSpec disabling, enabling, or providing
-  /// a base for floating point multiplication compression. If enabled,
-  /// pcodec will consider using float mult mode, which can substantially
-  /// improve compression ratio but decrease speed in some cases for floating
-  /// point types. If a base is provided, pcodec will use that base for
-  /// floating point multiplication compression. Enabled by default.
-  /// :param float_quant_spec: a FloatQuantSpec disabling or providing the
-  /// `bits` for floating point quantization compression. If provided, pcodec
-  /// will use that number of bits for floating point quantization compression.
-  /// To use quantization, float mult must be disabled. Disabled by default.
+  /// 
+  /// :param int_mult_spec: a IntMultSpec that configures whether integer
+  /// multiplier detection is enabled.
+  ///
+  /// Examples where this helps:
+  /// * nanosecond-precision timestamps that are mostly whole numbers of
+  /// microseconds, with a few exceptions
+  /// * integers `[7, 107, 207, 307, ... 100007]` shuffled
+  ///
+  /// When this is helpful, compression and decompression speeds can be
+  /// substantially reduced. This configuration may hurt
+  /// compression speed slightly even when it isn't helpful.
+  /// However, the compression ratio improvements tend to be large.
+  /// 
+  /// :param float_mult_spec: a FloatMultSpec that configures whether float
+  /// multiplier detection is enabled.
+  ///
+  /// Examples where this helps:
+  /// * approximate multiples of 0.01
+  /// * approximate multiples of pi
+  ///
+  /// Float mults can work even when there are NaNs and infinities.
+  /// When this is helpful, compression and decompression speeds can be
+  /// substantially reduced. In rare cases, this configuration
+  /// may reduce compression speed somewhat even when it isn't helpful.
+  /// However, the compression ratio improvements tend to be large.
+  /// 
+  /// :param float_quant_spec: a FloatQuantSpec that configures whether
+  /// quantized-float detection is enabled.
+  ///
+  /// Examples where this helps:
+  /// * float-valued data stored in a type that is unnecessarily wide (e.g.
+  /// stored as `f64`s where only a `f32` worth of precision is used)
+  /// 
   /// :param paging_spec: a PagingSpec describing how many numbers should
   /// go into each page.
   ///

--- a/pco_python/test/test_standalone.py
+++ b/pco_python/test/test_standalone.py
@@ -1,104 +1,112 @@
 import numpy as np
-from pcodec import standalone, ChunkConfig, PagingSpec
 import pytest
+
+from pcodec import ChunkConfig, PagingSpec, standalone
 
 np.random.seed(12345)
 
 all_shapes = (
-  [],
-  [900],
-  [9, 100],
+    [],
+    [900],
+    [9, 100],
 )
 
-all_dtypes = ('f2', 'f4', 'f8', 'i2', 'i4', 'i8', 'u2', 'u4', 'u8')
+all_dtypes = ("f2", "f4", "f8", "i2", "i4", "i8", "u2", "u4", "u8")
+
 
 @pytest.mark.parametrize("shape", all_shapes)
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_round_trip_decompress_into(shape, dtype):
-  data = np.random.uniform(0, 1000, size=shape).astype(dtype)
-  compressed = standalone.simple_compress(data, ChunkConfig())
+    data = np.random.uniform(0, 1000, size=shape).astype(dtype)
+    compressed = standalone.simple_compress(data, ChunkConfig())
 
-  # decompress exactly
-  out = np.empty_like(data)
-  progress = standalone.simple_decompress_into(compressed, out)
-  np.testing.assert_array_equal(data, out)
-  assert progress.n_processed == data.size
-  assert progress.finished
+    # decompress exactly
+    out = np.empty_like(data)
+    progress = standalone.simple_decompress_into(compressed, out)
+    np.testing.assert_array_equal(data, out)
+    assert progress.n_processed == data.size
+    assert progress.finished
 
 
 @pytest.mark.parametrize("shape", all_shapes)
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_round_trip_simple_decompress(shape, dtype):
-  data = np.random.uniform(0, 1000, size=shape).astype(dtype)
-  compressed = standalone.simple_compress(data, ChunkConfig(paging_spec=PagingSpec.equal_pages_up_to(300)))
-  out = standalone.simple_decompress(compressed)
-  # data are decompressed into a 1D array; ensure it can be reshaped to the original shape
-  out.shape = shape
-  np.testing.assert_array_equal(data, out)
+    data = np.random.uniform(0, 1000, size=shape).astype(dtype)
+    compressed = standalone.simple_compress(data, ChunkConfig(paging_spec=PagingSpec.equal_pages_up_to(300)))
+    out = standalone.simple_decompress(compressed)
+    # data are decompressed into a 1D array; ensure it can be reshaped to the original shape
+    out.shape = shape
+    np.testing.assert_array_equal(data, out)
 
 
 def test_inexact_decompression():
-  data = np.random.uniform(size=300)
-  compressed = standalone.simple_compress(data, ChunkConfig())
+    data = np.random.uniform(size=300)
+    compressed = standalone.simple_compress(data, ChunkConfig())
 
-  # decompress partially
-  out = np.zeros(3)
-  progress = standalone.simple_decompress_into(compressed, out)
-  np.testing.assert_array_equal(out, data[:3])
-  assert progress.n_processed == 3
-  assert not progress.finished
+    # decompress partially
+    out = np.zeros(3)
+    progress = standalone.simple_decompress_into(compressed, out)
+    np.testing.assert_array_equal(out, data[:3])
+    assert progress.n_processed == 3
+    assert not progress.finished
 
-  # decompress with room to spare
-  out = np.zeros(600)
-  progress = standalone.simple_decompress_into(compressed, out)
-  np.testing.assert_array_equal(out[:300], data)
-  np.testing.assert_array_equal(out[300:], np.zeros(300))
-  assert progress.n_processed == 300
-  assert progress.finished
+    # decompress with room to spare
+    out = np.zeros(600)
+    progress = standalone.simple_decompress_into(compressed, out)
+    np.testing.assert_array_equal(out[:300], data)
+    np.testing.assert_array_equal(out[300:], np.zeros(300))
+    assert progress.n_processed == 300
+    assert progress.finished
+
 
 def test_simple_decompress_into_errors():
-  """Test possible error states for standalone.simple_decompress_into"""
-  data = np.random.uniform(size=100).astype(np.float32)
-  compressed = standalone.simple_compress(data, ChunkConfig())
+    """Test possible error states for standalone.simple_decompress_into"""
+    data = np.random.uniform(size=100).astype(np.float32)
+    compressed = standalone.simple_compress(data, ChunkConfig())
 
-  out = np.zeros(100).astype(np.float64)
-  with pytest.raises(RuntimeError, match="data type byte does not match"):
-    standalone.simple_decompress_into(compressed, out)
+    out = np.zeros(100).astype(np.float64)
+    with pytest.raises(RuntimeError, match="data type byte does not match"):
+        standalone.simple_decompress_into(compressed, out)
 
 
 def test_simple_decompress_errors():
-  """Test possible error states for standalone.simple_decompress"""
-  data = np.random.uniform(size=100).astype(np.float32)
-  compressed = bytearray(standalone.simple_compress(data, ChunkConfig()))
+    """Test possible error states for standalone.simple_decompress"""
+    data = np.random.uniform(size=100).astype(np.float32)
+    compressed = bytearray(standalone.simple_compress(data, ChunkConfig()))
 
-  truncated = compressed[:8]
-  with pytest.raises(RuntimeError, match="empty bytes"):
-      standalone.simple_decompress(bytes(truncated))
+    truncated = compressed[:8]
+    with pytest.raises(RuntimeError, match="empty bytes"):
+        standalone.simple_decompress(bytes(truncated))
 
-  # corrupt the data with unknown dtype byte
-  # (is this safe to hard code? could the length of the header change in future version?)
-  compressed[8] = 99
-  with pytest.raises(RuntimeError, match="unrecognized dtype byte"):
-      standalone.simple_decompress(bytes(compressed))
+    # corrupt the data with unknown dtype byte
+    # (is this safe to hard code? could the length of the header change in future version?)
+    compressed[8] = 99
+    with pytest.raises(RuntimeError, match="unrecognized dtype byte"):
+        standalone.simple_decompress(bytes(compressed))
 
-  # this happens if the user passed in a file with no chunks.
-  compressed[8] = 0
-  assert standalone.simple_decompress(bytes(compressed)) is None
+    # this happens if the user passed in a file with no chunks.
+    compressed[8] = 0
+    assert standalone.simple_decompress(bytes(compressed)) is None
 
 
 def test_compression_options():
-  data = np.random.normal(size=100).astype(np.float32)
-  default_size = len(standalone.simple_compress(data, ChunkConfig()))
+    data = np.random.normal(size=100).astype(np.float32)
+    default_size = len(standalone.simple_compress(data, ChunkConfig()))
 
-  # this is mostly just to check that there is no error, but these settings
-  # should give worse compression than the defaults
-  assert len(standalone.simple_compress(
-    data,
-    ChunkConfig(
-      compression_level=0,
-      delta_encoding_order=1,
-      int_mult_spec='disabled',
-      float_mult_spec='DISABLED',
-      paging_spec=PagingSpec.equal_pages_up_to(77),
+    # this is mostly just to check that there is no error, but these settings
+    # should give worse compression than the defaults
+    assert (
+        len(
+            standalone.simple_compress(
+                data,
+                ChunkConfig(
+                    compression_level=0,
+                    delta_encoding_order=1,
+                    int_mult_spec="disabled",
+                    float_mult_spec="DISABLED",
+                    paging_spec=PagingSpec.equal_pages_up_to(77),
+                ),
+            )
+        )
+        > default_size
     )
-  )) > default_size

--- a/pco_python/test/test_standalone.py
+++ b/pco_python/test/test_standalone.py
@@ -131,34 +131,48 @@ def test_compression_options():
 def test_compression_int_mult_spec_options(int_mult_spec):
   data = (np.random.normal(size=100) * 1000).astype(np.int32)
 
-  # check for errors and that some compressed data was produced
-  assert (0 < len(standalone.simple_compress(
-      data,
-      ChunkConfig(int_mult_spec=int_mult_spec),
-  )) < data.nbytes)
+  # check for errors
+  compressed = standalone.simple_compress(
+    data,
+    ChunkConfig(int_mult_spec=int_mult_spec),
+  )
+
+  out = standalone.simple_decompress(compressed)
+
+  # check that the decompressed data is correct
+  np.testing.assert_array_equal(data, out)
 
 
 @pytest.mark.parametrize("float_mult_spec", all_float_mult_specs)
 def test_compression_float_mult_spec_options(float_mult_spec):
   data = (np.random.normal(size=100) * 1000).astype(np.int32) * np.pi
 
-  # check for errors and that some compressed data was produced
-  assert (0 < len(standalone.simple_compress(
-      data,
-      ChunkConfig(float_mult_spec=float_mult_spec),
-  )) < data.nbytes)
+  # check for errors
+  compressed = standalone.simple_compress(
+    data,
+    ChunkConfig(float_mult_spec=float_mult_spec),
+  )
+
+  out = standalone.simple_decompress(compressed)
+
+  # check that the decompressed data is correct
+  np.testing.assert_array_equal(data, out)
 
 
 @pytest.mark.parametrize("float_quant_spec", all_float_quant_specs)
 def test_compression_float_quant_spec_options(float_quant_spec):
   data = np.random.normal(size=100).astype(np.float32).astype(np.float64)
 
-  # check for errors and that some compressed data was produced
-  assert (0 < len(
-      standalone.simple_compress(
-          data,
-          ChunkConfig(
-              float_mult_spec=FloatMultSpec.disabled(),
-              float_quant_spec=float_quant_spec,
-          ),
-      )) < data.nbytes)
+  # check for errors
+  compressed = standalone.simple_compress(
+    data,
+    ChunkConfig(
+      float_mult_spec=FloatMultSpec.disabled(),
+      float_quant_spec=float_quant_spec,
+    ),
+  )
+
+  out = standalone.simple_decompress(compressed)
+
+  # check that the decompressed data is correct
+  np.testing.assert_array_equal(data, out)

--- a/pco_python/test/test_standalone.py
+++ b/pco_python/test/test_standalone.py
@@ -1,14 +1,13 @@
 import numpy as np
-import pytest
-
 from pcodec import ChunkConfig, FloatMultSpec, FloatQuantSpec, IntMultSpec, PagingSpec, standalone
+import pytest
 
 np.random.seed(12345)
 
 all_shapes = (
-    [],
-    [900],
-    [9, 100],
+  [],
+  [900],
+  [9, 100],
 )
 
 all_dtypes = ("f2", "f4", "f8", "i2", "i4", "i8", "u2", "u4", "u8")
@@ -37,151 +36,129 @@ all_float_quant_specs = (
 @pytest.mark.parametrize("shape", all_shapes)
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_round_trip_decompress_into(shape, dtype):
-    data = np.random.uniform(0, 1000, size=shape).astype(dtype)
-    compressed = standalone.simple_compress(data, ChunkConfig())
+  data = np.random.uniform(0, 1000, size=shape).astype(dtype)
+  compressed = standalone.simple_compress(data, ChunkConfig())
 
-    # decompress exactly
-    out = np.empty_like(data)
-    progress = standalone.simple_decompress_into(compressed, out)
-    np.testing.assert_array_equal(data, out)
-    assert progress.n_processed == data.size
-    assert progress.finished
+  # decompress exactly
+  out = np.empty_like(data)
+  progress = standalone.simple_decompress_into(compressed, out)
+  np.testing.assert_array_equal(data, out)
+  assert progress.n_processed == data.size
+  assert progress.finished
 
 
 @pytest.mark.parametrize("shape", all_shapes)
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_round_trip_simple_decompress(shape, dtype):
-    data = np.random.uniform(0, 1000, size=shape).astype(dtype)
-    compressed = standalone.simple_compress(data, ChunkConfig(paging_spec=PagingSpec.equal_pages_up_to(300)))
-    out = standalone.simple_decompress(compressed)
-    # data are decompressed into a 1D array; ensure it can be reshaped to the original shape
-    out.shape = shape
-    np.testing.assert_array_equal(data, out)
+  data = np.random.uniform(0, 1000, size=shape).astype(dtype)
+  compressed = standalone.simple_compress(data, ChunkConfig(paging_spec=PagingSpec.equal_pages_up_to(300)))
+  out = standalone.simple_decompress(compressed)
+  # data are decompressed into a 1D array; ensure it can be reshaped to the original shape
+  out.shape = shape
+  np.testing.assert_array_equal(data, out)
 
 
 def test_inexact_decompression():
-    data = np.random.uniform(size=300)
-    compressed = standalone.simple_compress(data, ChunkConfig())
+  data = np.random.uniform(size=300)
+  compressed = standalone.simple_compress(data, ChunkConfig())
 
-    # decompress partially
-    out = np.zeros(3)
-    progress = standalone.simple_decompress_into(compressed, out)
-    np.testing.assert_array_equal(out, data[:3])
-    assert progress.n_processed == 3
-    assert not progress.finished
+  # decompress partially
+  out = np.zeros(3)
+  progress = standalone.simple_decompress_into(compressed, out)
+  np.testing.assert_array_equal(out, data[:3])
+  assert progress.n_processed == 3
+  assert not progress.finished
 
-    # decompress with room to spare
-    out = np.zeros(600)
-    progress = standalone.simple_decompress_into(compressed, out)
-    np.testing.assert_array_equal(out[:300], data)
-    np.testing.assert_array_equal(out[300:], np.zeros(300))
-    assert progress.n_processed == 300
-    assert progress.finished
-
+  # decompress with room to spare
+  out = np.zeros(600)
+  progress = standalone.simple_decompress_into(compressed, out)
+  np.testing.assert_array_equal(out[:300], data)
+  np.testing.assert_array_equal(out[300:], np.zeros(300))
+  assert progress.n_processed == 300
+  assert progress.finished
 
 def test_simple_decompress_into_errors():
-    """Test possible error states for standalone.simple_decompress_into"""
-    data = np.random.uniform(size=100).astype(np.float32)
-    compressed = standalone.simple_compress(data, ChunkConfig())
+  """Test possible error states for standalone.simple_decompress_into"""
+  data = np.random.uniform(size=100).astype(np.float32)
+  compressed = standalone.simple_compress(data, ChunkConfig())
 
-    out = np.zeros(100).astype(np.float64)
-    with pytest.raises(RuntimeError, match="data type byte does not match"):
-        standalone.simple_decompress_into(compressed, out)
+  out = np.zeros(100).astype(np.float64)
+  with pytest.raises(RuntimeError, match="data type byte does not match"):
+    standalone.simple_decompress_into(compressed, out)
 
 
 def test_simple_decompress_errors():
-    """Test possible error states for standalone.simple_decompress"""
-    data = np.random.uniform(size=100).astype(np.float32)
-    compressed = bytearray(standalone.simple_compress(data, ChunkConfig()))
+  """Test possible error states for standalone.simple_decompress"""
+  data = np.random.uniform(size=100).astype(np.float32)
+  compressed = bytearray(standalone.simple_compress(data, ChunkConfig()))
 
-    truncated = compressed[:8]
-    with pytest.raises(RuntimeError, match="empty bytes"):
-        standalone.simple_decompress(bytes(truncated))
+  truncated = compressed[:8]
+  with pytest.raises(RuntimeError, match="empty bytes"):
+      standalone.simple_decompress(bytes(truncated))
 
-    # corrupt the data with unknown dtype byte
-    # (is this safe to hard code? could the length of the header change in future version?)
-    compressed[8] = 99
-    with pytest.raises(RuntimeError, match="unrecognized dtype byte"):
-        standalone.simple_decompress(bytes(compressed))
+  # corrupt the data with unknown dtype byte
+  # (is this safe to hard code? could the length of the header change in future version?)
+  compressed[8] = 99
+  with pytest.raises(RuntimeError, match="unrecognized dtype byte"):
+      standalone.simple_decompress(bytes(compressed))
 
-    # this happens if the user passed in a file with no chunks.
-    compressed[8] = 0
-    assert standalone.simple_decompress(bytes(compressed)) is None
+  # this happens if the user passed in a file with no chunks.
+  compressed[8] = 0
+  assert standalone.simple_decompress(bytes(compressed)) is None
 
 
 def test_compression_options():
-    data = np.random.normal(size=100).astype(np.float32)
-    default_size = len(standalone.simple_compress(data, ChunkConfig()))
+  data = np.random.normal(size=100).astype(np.float32)
+  default_size = len(standalone.simple_compress(data, ChunkConfig()))
 
-    # this is mostly just to check that there is no error, but these settings
-    # should give worse compression than the defaults
-    assert (
-        len(
-            standalone.simple_compress(
-                data,
-                ChunkConfig(
-                    compression_level=0,
-                    delta_encoding_order=1,
-                    int_mult_spec=IntMultSpec.disabled(),
-                    float_mult_spec=FloatMultSpec.disabled(),
-                    float_quant_spec=FloatQuantSpec.disabled(),
-                    paging_spec=PagingSpec.equal_pages_up_to(77),
-                ),
-            )
-        )
-        > default_size
-    )
+  # this is mostly just to check that there is no error, but these settings
+  # should give worse compression than the defaults
+  assert (len(
+      standalone.simple_compress(
+          data,
+          ChunkConfig(
+              compression_level=0,
+              delta_encoding_order=1,
+              int_mult_spec=IntMultSpec.disabled(),
+              float_mult_spec=FloatMultSpec.disabled(),
+              float_quant_spec=FloatQuantSpec.disabled(),
+              paging_spec=PagingSpec.equal_pages_up_to(77),
+          ),
+      )) > default_size)
 
 
 @pytest.mark.parametrize("int_mult_spec", all_int_mult_specs)
 def test_compression_int_mult_spec_options(int_mult_spec):
-    data = (np.random.normal(size=100) * 1000).astype(np.int32)
+  data = (np.random.normal(size=100) * 1000).astype(np.int32)
 
-    # check for errors and that some compressed data was produced
-    assert (
-        0
-        < len(
-            standalone.simple_compress(
-                data,
-                ChunkConfig(int_mult_spec=int_mult_spec),
-            )
-        )
-        < data.nbytes
-    )
+  # check for errors and that some compressed data was produced
+  assert (0 < len(standalone.simple_compress(
+      data,
+      ChunkConfig(int_mult_spec=int_mult_spec),
+  )) < data.nbytes)
 
 
 @pytest.mark.parametrize("float_mult_spec", all_float_mult_specs)
 def test_compression_float_mult_spec_options(float_mult_spec):
-    data = (np.random.normal(size=100) * 1000).astype(np.int32) * np.pi
+  data = (np.random.normal(size=100) * 1000).astype(np.int32) * np.pi
 
-    # check for errors and that some compressed data was produced
-    assert (
-        0
-        < len(
-            standalone.simple_compress(
-                data,
-                ChunkConfig(float_mult_spec=float_mult_spec),
-            )
-        )
-        < data.nbytes
-    )
+  # check for errors and that some compressed data was produced
+  assert (0 < len(standalone.simple_compress(
+      data,
+      ChunkConfig(float_mult_spec=float_mult_spec),
+  )) < data.nbytes)
 
 
 @pytest.mark.parametrize("float_quant_spec", all_float_quant_specs)
 def test_compression_float_quant_spec_options(float_quant_spec):
-    data = np.random.normal(size=100).astype(np.float32).astype(np.float64)
+  data = np.random.normal(size=100).astype(np.float32).astype(np.float64)
 
-    # check for errors and that some compressed data was produced
-    assert (
-        0
-        < len(
-            standalone.simple_compress(
-                data,
-                ChunkConfig(
-                    float_mult_spec=FloatMultSpec.disabled(),
-                    float_quant_spec=float_quant_spec,
-                ),
-            )
-        )
-        < data.nbytes
-    )
+  # check for errors and that some compressed data was produced
+  assert (0 < len(
+      standalone.simple_compress(
+          data,
+          ChunkConfig(
+              float_mult_spec=FloatMultSpec.disabled(),
+              float_quant_spec=float_quant_spec,
+          ),
+      )) < data.nbytes)

--- a/pco_python/test/test_wrapped.py
+++ b/pco_python/test/test_wrapped.py
@@ -1,49 +1,50 @@
 import numpy as np
-from pcodec import ChunkConfig, PagingSpec
-from pcodec.wrapped import FileCompressor, FileDecompressor
 import pytest
 
+from pcodec import ChunkConfig, PagingSpec, wrapped
+
 np.random.seed(12345)
-all_dtypes = ('f2', 'f4', 'f8', 'i2', 'i4', 'i8', 'u2', 'u4', 'u8')
+all_dtypes = ("f2", "f4", "f8", "i2", "i4", "i8", "u2", "u4", "u8")
+
 
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_compress(dtype):
-  data = np.random.uniform(0, 1000, size=[10]).astype(dtype)
-  pco_dtype = dtype[0].upper() + str(int(dtype[1]) * 8)
-  page_sizes = [6, 4] # so there are 2 pages
+    data = np.random.uniform(0, 1000, size=[10]).astype(dtype)
+    pco_dtype = dtype[0].upper() + str(int(dtype[1]) * 8)
+    page_sizes = [6, 4]  # so there are 2 pages
 
-  # compress
-  fc = FileCompressor()
-  header = fc.write_header()
-  cc = fc.chunk_compressor(
-    data,
-    ChunkConfig(paging_spec=PagingSpec.exact_page_sizes(page_sizes)),
-  )
-  assert cc.n_per_page() == page_sizes
-  chunk_meta = cc.write_chunk_meta()
-  page0 = cc.write_page(0)
-  page1 = cc.write_page(1)
-  with pytest.raises(RuntimeError, match="page idx exceeds num pages"):
-    cc.write_page(2)
+    # compress
+    fc = wrapped.FileCompressor()
+    header = fc.write_header()
+    cc = fc.chunk_compressor(
+        data,
+        ChunkConfig(paging_spec=PagingSpec.exact_page_sizes(page_sizes)),
+    )
+    assert cc.n_per_page() == page_sizes
+    chunk_meta = cc.write_chunk_meta()
+    page0 = cc.write_page(0)
+    page1 = cc.write_page(1)
+    with pytest.raises(RuntimeError, match="page idx exceeds num pages"):
+        cc.write_page(2)
 
-  # decompress
-  fd, n_bytes_read = FileDecompressor.from_header(header)
-  assert n_bytes_read == len(header)
-  # check that undershooting is fine
-  _, n_bytes_read = FileDecompressor.from_header(header + b'foo')
-  assert n_bytes_read == len(header)
-  cd, n_bytes_read = fd.read_chunk_meta(chunk_meta, pco_dtype)
-  assert n_bytes_read == len(chunk_meta)
+    # decompress
+    fd, n_bytes_read = wrapped.FileDecompressor.from_header(header)
+    assert n_bytes_read == len(header)
+    # check that undershooting is fine
+    _, n_bytes_read = wrapped.FileDecompressor.from_header(header + b"foo")
+    assert n_bytes_read == len(header)
+    cd, n_bytes_read = fd.read_chunk_meta(chunk_meta, pco_dtype)
+    assert n_bytes_read == len(chunk_meta)
 
-  # page 1, which has elements 6-10
-  dst1 = np.zeros(100).astype(dtype)
-  progress, n_bytes_read = cd.read_page_into(page1, 4, dst1)
-  np.testing.assert_array_equal(dst1[4:], np.zeros(96))
-  np.testing.assert_array_equal(dst1[:4], data[6:])
-  assert n_bytes_read == len(page1)
+    # page 1, which has elements 6-10
+    dst1 = np.zeros(100).astype(dtype)
+    progress, n_bytes_read = cd.read_page_into(page1, 4, dst1)
+    np.testing.assert_array_equal(dst1[4:], np.zeros(96))
+    np.testing.assert_array_equal(dst1[:4], data[6:])
+    assert n_bytes_read == len(page1)
 
-  # page 0, which has elements 0-6
-  dst0 = np.zeros(6).astype(dtype)
-  progress, n_bytes_read = cd.read_page_into(page0, 6, dst0)
-  np.testing.assert_array_equal(dst0, data[:6])
-  assert n_bytes_read == len(page0)
+    # page 0, which has elements 0-6
+    dst0 = np.zeros(6).astype(dtype)
+    progress, n_bytes_read = cd.read_page_into(page0, 6, dst0)
+    np.testing.assert_array_equal(dst0, data[:6])
+    assert n_bytes_read == len(page0)

--- a/pco_python/test/test_wrapped.py
+++ b/pco_python/test/test_wrapped.py
@@ -1,50 +1,49 @@
 import numpy as np
+from pcodec import ChunkConfig, PagingSpec
+from pcodec.wrapped import FileCompressor, FileDecompressor
 import pytest
 
-from pcodec import ChunkConfig, PagingSpec, wrapped
-
 np.random.seed(12345)
-all_dtypes = ("f2", "f4", "f8", "i2", "i4", "i8", "u2", "u4", "u8")
-
+all_dtypes = ('f2', 'f4', 'f8', 'i2', 'i4', 'i8', 'u2', 'u4', 'u8')
 
 @pytest.mark.parametrize("dtype", all_dtypes)
 def test_compress(dtype):
-    data = np.random.uniform(0, 1000, size=[10]).astype(dtype)
-    pco_dtype = dtype[0].upper() + str(int(dtype[1]) * 8)
-    page_sizes = [6, 4]  # so there are 2 pages
+  data = np.random.uniform(0, 1000, size=[10]).astype(dtype)
+  pco_dtype = dtype[0].upper() + str(int(dtype[1]) * 8)
+  page_sizes = [6, 4] # so there are 2 pages
 
-    # compress
-    fc = wrapped.FileCompressor()
-    header = fc.write_header()
-    cc = fc.chunk_compressor(
-        data,
-        ChunkConfig(paging_spec=PagingSpec.exact_page_sizes(page_sizes)),
-    )
-    assert cc.n_per_page() == page_sizes
-    chunk_meta = cc.write_chunk_meta()
-    page0 = cc.write_page(0)
-    page1 = cc.write_page(1)
-    with pytest.raises(RuntimeError, match="page idx exceeds num pages"):
-        cc.write_page(2)
+  # compress
+  fc = FileCompressor()
+  header = fc.write_header()
+  cc = fc.chunk_compressor(
+    data,
+    ChunkConfig(paging_spec=PagingSpec.exact_page_sizes(page_sizes)),
+  )
+  assert cc.n_per_page() == page_sizes
+  chunk_meta = cc.write_chunk_meta()
+  page0 = cc.write_page(0)
+  page1 = cc.write_page(1)
+  with pytest.raises(RuntimeError, match="page idx exceeds num pages"):
+    cc.write_page(2)
 
-    # decompress
-    fd, n_bytes_read = wrapped.FileDecompressor.from_header(header)
-    assert n_bytes_read == len(header)
-    # check that undershooting is fine
-    _, n_bytes_read = wrapped.FileDecompressor.from_header(header + b"foo")
-    assert n_bytes_read == len(header)
-    cd, n_bytes_read = fd.read_chunk_meta(chunk_meta, pco_dtype)
-    assert n_bytes_read == len(chunk_meta)
+  # decompress
+  fd, n_bytes_read = FileDecompressor.from_header(header)
+  assert n_bytes_read == len(header)
+  # check that undershooting is fine
+  _, n_bytes_read = FileDecompressor.from_header(header + b'foo')
+  assert n_bytes_read == len(header)
+  cd, n_bytes_read = fd.read_chunk_meta(chunk_meta, pco_dtype)
+  assert n_bytes_read == len(chunk_meta)
 
-    # page 1, which has elements 6-10
-    dst1 = np.zeros(100).astype(dtype)
-    progress, n_bytes_read = cd.read_page_into(page1, 4, dst1)
-    np.testing.assert_array_equal(dst1[4:], np.zeros(96))
-    np.testing.assert_array_equal(dst1[:4], data[6:])
-    assert n_bytes_read == len(page1)
+  # page 1, which has elements 6-10
+  dst1 = np.zeros(100).astype(dtype)
+  progress, n_bytes_read = cd.read_page_into(page1, 4, dst1)
+  np.testing.assert_array_equal(dst1[4:], np.zeros(96))
+  np.testing.assert_array_equal(dst1[:4], data[6:])
+  assert n_bytes_read == len(page1)
 
-    # page 0, which has elements 0-6
-    dst0 = np.zeros(6).astype(dtype)
-    progress, n_bytes_read = cd.read_page_into(page0, 6, dst0)
-    np.testing.assert_array_equal(dst0, data[:6])
-    assert n_bytes_read == len(page0)
+  # page 0, which has elements 0-6
+  dst0 = np.zeros(6).astype(dtype)
+  progress, n_bytes_read = cd.read_page_into(page0, 6, dst0)
+  np.testing.assert_array_equal(dst0, data[:6])
+  assert n_bytes_read == len(page0)


### PR DESCRIPTION
# Summary
This PR adds missing options to the `PyChunkConfig` and aligns it with `ChunkConfig`. This is done by adding three new wrapper classes. 

`PyFloatMultSpec` and `PyFloatQuantSpec` are used for the `int_mult_spec` and `float_mult_spec` properties instead of `String`. This allows `base` values to passed in using the `provided` function. `Enabled` and `Disabled` are now set using the `enabled` and `disabled` functions, rather than passing in strings.

The `float_quant_spec` property of type `PyFloatQuantSpec` has been added to `PyChunkConfig`. This works similar to the other two wrappers.

This fixes #202.

# Tasks done
- [x] Add `PyIntMultSpec` class
- [x] Add `PyFloatMultSpec` class
- [x] Add `PyFloatQuantSpec` class
- [x] Update `PyChunkConfig` to use the three classes above
- [x] Update docstrings
- [x] Add Python tests for new options

