### PR TITLE
f16 dataset, 16-bit wavs, fixed f16 naming in bench subcommand

### DIFF
--- a/pco_cli/generate_randoms.py
+++ b/pco_cli/generate_randoms.py
@@ -54,6 +54,13 @@ def write_i64(arr, name, base_dir):
   write_generic(strs, arr, full_name, base_dir)
 
 @writer
+def write_f16(arr, name, base_dir):
+  arr = arr.astype(np.float16)
+  strs = [str(x) for x in arr]
+  full_name = f'f16_{name}'
+  write_generic(strs, arr, full_name, base_dir)
+
+@writer
 def write_f32(arr, name, base_dir):
   arr = arr.astype(np.float32)
   strs = [str(x) for x in arr]
@@ -156,8 +163,8 @@ def slow_cosine():
   period = n / periods
   return 100_000 * np.cos(np.arange(n) * 2 * np.pi / period)
 
-# Including f32 mostly just to test performance bottlenecks on f32
-@datagen('f64', 'f32')
+# Including lower precisions mostly just to test performance bottlenecks
+@datagen('f64', 'f32', 'f16')
 def normal():
   return np.random.normal(size=n)
 

--- a/pco_cli/src/bench/mod.rs
+++ b/pco_cli/src/bench/mod.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::uninit_vec)]
 
-use std::any::type_name;
 use std::collections::HashMap;
-use std::fs;
 use std::ops::AddAssign;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
+use std::{any, fs};
 
 use anyhow::{anyhow, Result};
 use arrow::datatypes::{DataType, Schema};
@@ -184,17 +183,20 @@ impl BenchStat {
   }
 }
 
+fn type_basename<T>() -> String {
+  any::type_name::<T>().split(':').last().unwrap().to_string()
+}
+
 fn core_dtype_to_str(dtype: CoreDataType) -> String {
-  macro_rules! to_str {
+  macro_rules! to_string {
     {$($name:ident($lname:ident) => $t:ty,)+} => {
       match dtype {
-        $(CoreDataType::$name => type_name::<$t>(),)+
+        $(CoreDataType::$name => type_basename::<$t>(),)+
       }
     }
   }
 
-  let name = with_core_dtypes!(to_str);
-  name.to_string()
+  with_core_dtypes!(to_string)
 }
 
 fn handle_column(


### PR DESCRIPTION
* added f16_normal to generate_randoms.py
* interpreted most wav data as 16-bit instead of 32-bit now
* fixed issue where `bench` printed out the fully qualified type name for f16 (half): `│ half::binary16::f16_normal │ pco   │   19.8805ms │    1.790916ms │         1691993 │`