### PR TITLE
Revise minimum versions of `half` and `bytes`

### DIFF
--- a/pco/Cargo.toml
+++ b/pco/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.73.0"
 
 [dependencies]
 better_io = { version = "0.1.0", path = "../better_io" }
-half = { version = "2.4.1", features = ["std"] }
+half = { version = "2.0.0", features = ["std"] }
 rand_xoshiro = { version = "0.6.0" }
 
 [dev-dependencies]

--- a/pco_c/Cargo.toml
+++ b/pco_c/Cargo.toml
@@ -8,6 +8,6 @@ name = "cpcodec"
 crate-type = ["dylib"]
 
 [dependencies]
-half = { version = "2.4.1", features = ["std"] }
+half = { version = "2.0.0", features = ["std"] }
 libc = "0.2.132"
 pco = { version = "0.3.0", path = "../pco" }

--- a/pco_cli/Cargo.toml
+++ b/pco_cli/Cargo.toml
@@ -22,7 +22,7 @@ better_io = { version = "0.1.0", path = "../better_io" }
 blosc-src = { version = "0.3", features = ["zstd"], optional = true }
 bytes = "1.1.0"
 clap = { version = "4.5.3", features = ["derive"] }
-half = { version = "2.4.1", features = ["std"] }
+half = { version = "2.1.0", features = ["std"] }
 indicatif = "0.17.8"
 parquet = { version = "49.0.0", features = [
   "arrow",

--- a/pco_cli/Cargo.toml
+++ b/pco_cli/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.71"
 arrow = { version = "49.0.0", features = ["csv"], default-features = false }
 better_io = { version = "0.1.0", path = "../better_io" }
 blosc-src = { version = "0.3", features = ["zstd"], optional = true }
-bytes = "1.1.0"
+bytes = "1.4.0"
 clap = { version = "4.5.3", features = ["derive"] }
 half = { version = "2.1.0", features = ["std"] }
 indicatif = "0.17.8"

--- a/pco_python/Cargo.toml
+++ b/pco_python/Cargo.toml
@@ -12,7 +12,7 @@ name = "pcodec"
 crate-type = ["cdylib"]
 
 [dependencies]
-half = { version = "2.4.1", features = ["std"] }
+half = { version = "2.0.0", features = ["std"] }
 numpy = { version = "0.20.0", features = ["half"] }
 pco = { version = "0.3.0", path = "../pco" }
 pyo3 = { version = "0.20.0", features = ["extension-module"] }


### PR DESCRIPTION
The `half` minimum version is relaxed from 2.4.1 to 2.0.0 for most of the `pco` crates.

For `pco_cli`, `half` is relaxed to 2.1.0 and `bytes` increased from 1.1.0 to 1.4.0.
These minimum versions are set by the `arrow` related deps.