### PR TITLE
Simpler min-max functions that vectorize

### DIFF
--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -44,30 +44,22 @@ pub struct HistogramBin<L: Latent> {
 }
 
 fn slice_min<L: Latent>(latents: &[L]) -> L {
-  let mut min_val = L::MAX;
-  for i in 0..latents.len() {
-    min_val = min(min_val, latents[i]);
-  }
-  min_val
+  latents
+    .iter()
+    .fold(L::MAX, |min_val, val| min(min_val, *val))
 }
 
 fn slice_max<L: Latent>(latents: &[L]) -> L {
-  let mut max_val = L::ZERO;
-  for i in 0..latents.len() {
-    max_val = max(max_val, latents[i]);
-  }
-  max_val
+  latents
+    .iter()
+    .fold(L::ZERO, |max_val, val| max(max_val, *val))
 }
 
 fn slice_min_max<L: Latent>(latents: &[L]) -> (L, L) {
-  let mut min_val = L::MAX;
-  let mut max_val = L::ZERO;
-  for i in 0..latents.len() {
-    let val = latents[i];
-    min_val = min(min_val, val);
-    max_val = max(max_val, val);
-  }
-  (min_val, max_val)
+  latents.iter().fold(
+    (L::MAX, L::ZERO),
+    |(min_val, max_val), val| (min(min_val, *val), max(max_val, *val)),
+  )
 }
 
 struct HistogramBuilder<L: Latent> {

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -46,13 +46,15 @@ pub struct HistogramBin<L: Latent> {
 fn slice_min<L: Latent>(latents: &[L]) -> L {
   latents
     .iter()
-    .fold(L::MAX, |min_val, val| min(min_val, *val))
+    .cloned()
+    .fold(L::MAX, |min_val, val| min(min_val, val))
 }
 
 fn slice_max<L: Latent>(latents: &[L]) -> L {
   latents
     .iter()
-    .fold(L::ZERO, |max_val, val| max(max_val, *val))
+    .cloned()
+    .fold(L::ZERO, |max_val, val| max(max_val, val))
 }
 
 fn slice_min_max<L: Latent>(latents: &[L]) -> (L, L) {

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -98,16 +98,16 @@ impl<L: Latent> HistogramBuilder<L> {
 
     if let Some(bin) = self.incomplete_bin.as_mut() {
       bin.upper = match upper {
-        Bound::Loose(_) => slice_max(latents),
         Bound::Tight(upper) => upper,
+        Bound::Loose(_) => slice_max(latents),
       };
       bin.count += latents.len();
     } else {
       let (tight_lb, tight_ub) = match (lower, upper) {
         (Bound::Tight(lower), Bound::Tight(upper)) => (lower, upper),
-        (Bound::Loose(_), Bound::Loose(_)) => slice_min_max(latents),
         (Bound::Tight(lower), Bound::Loose(_)) => (lower, slice_max(latents)),
         (Bound::Loose(_), Bound::Tight(upper)) => (slice_min(latents), upper),
+        (Bound::Loose(_), Bound::Loose(_)) => slice_min_max(latents),
       };
       self.incomplete_bin = Some(HistogramBin {
         count: latents.len(),

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -101,15 +101,11 @@ impl<L: Latent> HistogramBuilder<L> {
       };
       bin.count += latents.len();
     } else {
-      let (tight_lb, tight_ub) = match lower {
-        Bound::Loose(_) => match upper {
-          Bound::Loose(_) => slice_min_max(latents),
-          Bound::Tight(upper) => (slice_min(latents), upper),
-        },
-        Bound::Tight(lower) => match upper {
-          Bound::Loose(_) => (lower, slice_max(latents)),
-          Bound::Tight(upper) => (lower, upper),
-        },
+      let (tight_lb, tight_ub) = match (lower, upper) {
+        (Bound::Tight(lower), Bound::Tight(upper)) => (lower, upper),
+        (Bound::Loose(_), Bound::Loose(_)) => slice_min_max(latents),
+        (Bound::Tight(lower), Bound::Loose(_)) => (lower, slice_max(latents)),
+        (Bound::Loose(_), Bound::Tight(upper)) => (slice_min(latents), upper),
       };
       self.incomplete_bin = Some(HistogramBin {
         count: latents.len(),

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -44,17 +44,11 @@ pub struct HistogramBin<L: Latent> {
 }
 
 fn slice_min<L: Latent>(latents: &[L]) -> L {
-  latents
-    .iter()
-    .cloned()
-    .fold(L::MAX, |min_val, val| min(min_val, val))
+  latents.iter().cloned().fold(L::MAX, min)
 }
 
 fn slice_max<L: Latent>(latents: &[L]) -> L {
-  latents
-    .iter()
-    .cloned()
-    .fold(L::ZERO, |max_val, val| max(max_val, val))
+  latents.iter().cloned().fold(L::ZERO, max)
 }
 
 fn slice_min_max<L: Latent>(latents: &[L]) -> (L, L) {

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -56,9 +56,9 @@ fn slice_max<L: Latent>(latents: &[L]) -> L {
 }
 
 fn slice_min_max<L: Latent>(latents: &[L]) -> (L, L) {
-  latents.iter().fold(
+  latents.iter().cloned().fold(
     (L::MAX, L::ZERO),
-    |(min_val, max_val), val| (min(min_val, *val), max(max_val, *val)),
+    |(min_val, max_val), val| (min(min_val, val), max(max_val, val)),
   )
 }
 

--- a/pco/src/histograms.rs
+++ b/pco/src/histograms.rs
@@ -98,16 +98,16 @@ impl<L: Latent> HistogramBuilder<L> {
 
     if let Some(bin) = self.incomplete_bin.as_mut() {
       bin.upper = match upper {
-        Bound::Tight(upper) => upper,
         Bound::Loose(_) => slice_max(latents),
+        Bound::Tight(upper) => upper,
       };
       bin.count += latents.len();
     } else {
       let (tight_lb, tight_ub) = match (lower, upper) {
-        (Bound::Tight(lower), Bound::Tight(upper)) => (lower, upper),
-        (Bound::Tight(lower), Bound::Loose(_)) => (lower, slice_max(latents)),
-        (Bound::Loose(_), Bound::Tight(upper)) => (slice_min(latents), upper),
         (Bound::Loose(_), Bound::Loose(_)) => slice_min_max(latents),
+        (Bound::Loose(_), Bound::Tight(upper)) => (slice_min(latents), upper),
+        (Bound::Tight(lower), Bound::Loose(_)) => (lower, slice_max(latents)),
+        (Bound::Tight(lower), Bound::Tight(upper)) => (lower, upper),
       };
       self.incomplete_bin = Some(HistogramBin {
         count: latents.len(),


### PR DESCRIPTION
# Background
The current `slice_min` and `slice_max` functions are not very clean, [nor do they seem to vectorize](https://rust.godbolt.org/z/537xGvj8r).

# Changes
I've replaced the for-loops with `latents.iter().fold()`, which appears to be vectorized by the compiler.

I've added a new `slice_min_max` function that gets both values in one iteration. To use this effectively I've had to make a change to `apply_incomplete`, which I admit is not the cleanest. Suggestions are welcome!

# Performance
~~Honestly, I'm not able to see any repeatable change in performance when running the benchmarks. I've done some digging and it appears the time spent in the min-max functions is so little that I cannot properly benchmark it.~~

~~@mwlon, do you know any scenarios which will cause more time to be spent in these functions that we could use to benchmark this properly? If not, then I don't think there's much point spending more time here.~~

Running 
```
cargo run --release -- bench -i data/binary/ --input-format binary --codecs pco:level=0 --iters 100
```
this PR appears to net ~5% reduction in total time, while 
```
cargo run --release -- bench -i data/binary/ --input-format binary --codecs pco:level=2 --iters 100
```
is ~2% faster. For higher compression levels the effect appears to be insignificant.