### PR TITLE
Replaced `log2()` with `log(2.0)` on Windows, fixes #223

### DIFF
--- a/pco/src/bin_optimization.rs
+++ b/pco/src/bin_optimization.rs
@@ -16,6 +16,11 @@ fn bin_cost<L: Latent>(
   total_count_log2: f32,
 ) -> f32 {
   let count = count as f32;
+  // On Windows, log2() is very slow, so we use log(2.0) instead, which is
+  // about 10x faster. On other platforms, we stick with log2(). See #223.
+  #[cfg(target_os = "windows")]
+  let ans_cost = total_count_log2 - count.log(2.0);
+  #[cfg(not(target_os = "windows"))]
   let ans_cost = total_count_log2 - count.log2();
   let offset_cost = bits::bits_to_encode_offset(upper - lower) as f32;
   bin_meta_cost + (ans_cost + offset_cost) * count
@@ -42,6 +47,11 @@ fn choose_optimized_partitioning<L: Latent>(
   let total_count = c;
   let lowers = bins.iter().map(|bin| bin.lower).collect::<Vec<_>>();
   let uppers = bins.iter().map(|bin| bin.upper).collect::<Vec<_>>();
+  // On Windows, log2() is very slow, so we use log(2.0) instead, which is
+  // about 10x faster. On other platforms, we stick with log2(). See #223.
+  #[cfg(target_os = "windows")]
+  let total_count_log2 = (c as f32).log(2.0);
+  #[cfg(not(target_os = "windows"))]
   let total_count_log2 = (c as f32).log2();
 
   let mut best_partitionings = Vec::with_capacity(bins.len() + 1);

--- a/pco/src/bin_optimization.rs
+++ b/pco/src/bin_optimization.rs
@@ -47,11 +47,6 @@ fn choose_optimized_partitioning<L: Latent>(
   let total_count = c;
   let lowers = bins.iter().map(|bin| bin.lower).collect::<Vec<_>>();
   let uppers = bins.iter().map(|bin| bin.upper).collect::<Vec<_>>();
-  // On Windows, log2() is very slow, so we use log(2.0) instead, which is
-  // about 10x faster. On other platforms, we stick with log2(). See #223.
-  #[cfg(target_os = "windows")]
-  let total_count_log2 = (c as f32).log(2.0);
-  #[cfg(not(target_os = "windows"))]
   let total_count_log2 = (c as f32).log2();
 
   let mut best_partitionings = Vec::with_capacity(bins.len() + 1);


### PR DESCRIPTION
This PR replaces `log2()` with `log(2.0)` on Windows. The motivation is that `log2()` is *very* slow on Windows making `log(2.0)` about 10x faster.

See #223 for more details.