### PR TITLE
Fixed out-of-bounds when generating random on Windows

### DIFF
--- a/pco_cli/generate_randoms.py
+++ b/pco_cli/generate_randoms.py
@@ -126,7 +126,7 @@ def lomax05():
 
 @datagen("i64")
 def uniform():
-    return np.random.randint(-(2**63), 2**63, size=max_n)[:n]
+    return np.random.randint(-(2**63), 2**63, size=max_n, dtype=np.int64)[:n]
 
 
 # disable the following by default because it's kinda a waste of disk:


### PR DESCRIPTION
The function
``` python
@datagen("i64")
def uniform():
    return np.random.randint(-(2**63), 2**63, size=max_n)[:n]
```
raises an error on Windows due to using `i32` type.

```
Traceback (most recent call last):
  File "...\generate_randoms.py", line 352, in <module>
    data = f()
  File "...\generate_randoms.py", line 129, in uniform
    return np.random.randint(-(2**63), 2**63, size=max_n)[:n]
  File "numpy\\random\\mtrand.pyx", line 780, in numpy.random.mtrand.RandomState.randint
  File "numpy\\random\\_bounded_integers.pyx", line 2877, in numpy.random._bounded_integers._rand_int32
ValueError: low is out of bounds for int32
```

Specifying `dtype=np.int64` fixes this.