### PR TITLE
Removed `lookback_goodness_argmax`

### DIFF
--- a/pco/src/delta.rs
+++ b/pco/src/delta.rs
@@ -133,7 +133,7 @@ fn lookback_compute_goodness<L: Latent>(
   lookback_counts: &mut [u32],
 ) -> usize {
   let mut best_goodness = 0;
-  let mut best_idx = 0;
+  let mut best_lookback: usize = 0;
   for lookback_idx in 0..PROPOSED_LOOKBACKS {
     let lookback = proposed_lookbacks[lookback_idx];
     let lookback_count = lookback_counts[lookback - 1];
@@ -144,10 +144,10 @@ fn lookback_compute_goodness<L: Latent>(
     let goodness = lookback_goodness + delta_goodness;
     if goodness > best_goodness {
       best_goodness = goodness;
-      best_idx = lookback_idx;
+      best_lookback = lookback;
     }
   }
-  best_idx
+  best_lookback
 }
 
 #[inline(never)]
@@ -186,14 +186,13 @@ fn choose_lookbacks<L: Latent>(config: DeltaLookbackConfig, latents: &[L]) -> Ve
       &mut idx_hash_table,
       &mut proposed_lookbacks,
     );
-    let best_lookback_idx = lookback_compute_goodness(
+    let new_best_lookback = lookback_compute_goodness(
       l,
       i,
       latents,
       &proposed_lookbacks,
       &mut lookback_counts,
     );
-    let new_best_lookback = proposed_lookbacks[best_lookback_idx];
     if new_best_lookback != best_lookback {
       repeating_lookback_idx += 1;
     }

--- a/pco/src/delta.rs
+++ b/pco/src/delta.rs
@@ -131,8 +131,9 @@ fn lookback_compute_goodness<L: Latent>(
   latents: &[L],
   proposed_lookbacks: &[usize; PROPOSED_LOOKBACKS],
   lookback_counts: &mut [u32],
-  goodnesses: &mut [Bitlen; PROPOSED_LOOKBACKS],
-) {
+) -> usize {
+  let mut best_goodness = 0;
+  let mut best_idx = 0;
   for lookback_idx in 0..PROPOSED_LOOKBACKS {
     let lookback = proposed_lookbacks[lookback_idx];
     let lookback_count = lookback_counts[lookback - 1];
@@ -140,21 +141,12 @@ fn lookback_compute_goodness<L: Latent>(
     let lookback_goodness = Bitlen::BITS - lookback_count.leading_zeros();
     let delta = L::min(l.wrapping_sub(other), other.wrapping_sub(l));
     let delta_goodness = delta.leading_zeros();
-    goodnesses[lookback_idx] = lookback_goodness + delta_goodness;
-  }
-}
-
-fn lookback_goodness_argmax(goodnesses: &[Bitlen; PROPOSED_LOOKBACKS]) -> usize {
-  let mut best_goodness = goodnesses[0];
-  let mut best_idx = 0;
-
-  for (i, &goodness) in goodnesses.iter().enumerate().skip(1) {
+    let goodness = lookback_goodness + delta_goodness;
     if goodness > best_goodness {
       best_goodness = goodness;
-      best_idx = i;
+      best_idx = lookback_idx;
     }
   }
-
   best_idx
 }
 
@@ -178,7 +170,6 @@ fn choose_lookbacks<L: Latent>(config: DeltaLookbackConfig, latents: &[L]) -> Ve
   let mut lookbacks = vec![MaybeUninit::uninit(); latents.len() - state_n];
   let mut idx_hash_table = vec![0_usize; COARSENESSES.len() * hash_table_n];
   let mut proposed_lookbacks = array::from_fn::<_, PROPOSED_LOOKBACKS, _>(|i| (i + 1).min(state_n));
-  let mut goodnesses = [0; PROPOSED_LOOKBACKS];
   let mut best_lookback = 1;
   let mut repeating_lookback_idx: usize = 0;
   for i in state_n..latents.len() {
@@ -195,15 +186,13 @@ fn choose_lookbacks<L: Latent>(config: DeltaLookbackConfig, latents: &[L]) -> Ve
       &mut idx_hash_table,
       &mut proposed_lookbacks,
     );
-    lookback_compute_goodness(
+    let best_lookback_idx = lookback_compute_goodness(
       l,
       i,
       latents,
       &proposed_lookbacks,
       &mut lookback_counts,
-      &mut goodnesses,
     );
-    let best_lookback_idx = lookback_goodness_argmax(&goodnesses);
     let new_best_lookback = proposed_lookbacks[best_lookback_idx];
     if new_best_lookback != best_lookback {
       repeating_lookback_idx += 1;

--- a/pco/src/delta.rs
+++ b/pco/src/delta.rs
@@ -126,7 +126,7 @@ fn lookback_hash_lookup(
 }
 
 #[inline(never)]
-fn lookback_compute_goodness<L: Latent>(
+fn find_best_lookback<L: Latent>(
   l: L,
   i: usize,
   latents: &[L],
@@ -135,8 +135,7 @@ fn lookback_compute_goodness<L: Latent>(
 ) -> usize {
   let mut best_goodness = 0;
   let mut best_lookback: usize = 0;
-  for lookback_idx in 0..PROPOSED_LOOKBACKS {
-    let lookback = proposed_lookbacks[lookback_idx];
+  for &lookback in proposed_lookbacks {
     let (lookback_count, other) = unsafe {
       (
         *lookback_counts.get_unchecked(lookback - 1),
@@ -191,7 +190,7 @@ fn choose_lookbacks<L: Latent>(config: DeltaLookbackConfig, latents: &[L]) -> Ve
       &mut idx_hash_table,
       &mut proposed_lookbacks,
     );
-    let new_best_lookback = lookback_compute_goodness(
+    let new_best_lookback = find_best_lookback(
       l,
       i,
       latents,

--- a/pco/src/delta.rs
+++ b/pco/src/delta.rs
@@ -125,6 +125,7 @@ fn lookback_hash_lookup(
   }
 }
 
+#[inline(never)]
 fn lookback_compute_goodness<L: Latent>(
   l: L,
   i: usize,
@@ -136,8 +137,12 @@ fn lookback_compute_goodness<L: Latent>(
   let mut best_lookback: usize = 0;
   for lookback_idx in 0..PROPOSED_LOOKBACKS {
     let lookback = proposed_lookbacks[lookback_idx];
-    let lookback_count = lookback_counts[lookback - 1];
-    let other = unsafe { *latents.get_unchecked(i - lookback) };
+    let (lookback_count, other) = unsafe {
+      (
+        *lookback_counts.get_unchecked(lookback - 1),
+        *latents.get_unchecked(i - lookback),
+      )
+    };
     let lookback_goodness = Bitlen::BITS - lookback_count.leading_zeros();
     let delta = L::min(l.wrapping_sub(other), other.wrapping_sub(l));
     let delta_goodness = delta.leading_zeros();

--- a/pco_cli/src/dtypes.rs
+++ b/pco_cli/src/dtypes.rs
@@ -181,7 +181,7 @@ impl Parquetable for f16 {
     nums.iter().map(|x| x.to_f32()).collect()
   }
   fn parquet_to_nums(vec: Vec<f32>) -> Vec<Self> {
-    vec.into_iter().map(|x| f16::from_f32(x)).collect()
+    vec.into_iter().map(f16::from_f32).collect()
   }
 }
 


### PR DESCRIPTION
Simplifies code and benchmarks indicate this change will improve performance.
```
cargo run --release -- bench -i data/binary/ --input-format binary -d interl --iters 100

Laptop (Intel® Core™ i7-1370P Processor):
main:
╭─────────────────────┬───────┬─────────────┬───────────────┬─────────────────╮      
│ dataset             │ codec │ compress_dt │ decompress_dt │ compressed_size │      
├─────────────────────┼───────┼─────────────┼───────────────┼─────────────────┤      
│ i32_interl0         │ pco   │  58.78775ms │     4.01065ms │          890794 │      
│ i64_interl0         │ pco   │  62.42405ms │      4.7225ms │          891168 │      
│ i32_interl1         │ pco   │   59.0238ms │      3.9483ms │          541198 │      
│ i64_interl1         │ pco   │  64.43565ms │     4.83275ms │          541270 │      
│ i32_interl_scrambl1 │ pco   │  64.15285ms │      4.1004ms │         1106568 │      
│ i64_interl_scrambl1 │ pco   │  69.67635ms │      5.1856ms │         1106654 │      
│ <sum>               │ pco   │ 378.50045ms │     26.8002ms │         5077652 │      
│ <sum>               │ <sum> │ 378.50045ms │     26.8002ms │         5077652 │      
╰─────────────────────┴───────┴─────────────┴───────────────┴─────────────────╯
no-argmax:
╭─────────────────────┬───────┬─────────────┬───────────────┬─────────────────╮      
│ dataset             │ codec │ compress_dt │ decompress_dt │ compressed_size │      
├─────────────────────┼───────┼─────────────┼───────────────┼─────────────────┤      
│ i32_interl0         │ pco   │   58.1858ms │     3.96095ms │          890794 │      
│ i64_interl0         │ pco   │   62.4123ms │     4.72745ms │          891168 │      
│ i32_interl1         │ pco   │   56.7742ms │     3.86515ms │          541198 │      
│ i64_interl1         │ pco   │    62.386ms │      4.7476ms │          541270 │      
│ i32_interl_scrambl1 │ pco   │  63.87445ms │      4.0084ms │         1106568 │      
│ i64_interl_scrambl1 │ pco   │    67.999ms │      5.0584ms │         1106654 │      
│ <sum>               │ pco   │ 371.63175ms │    26.36795ms │         5077652 │      
│ <sum>               │ <sum> │ 371.63175ms │    26.36795ms │         5077652 │      
╰─────────────────────┴───────┴─────────────┴───────────────┴─────────────────╯ 
vectorized-lookback-goodness:
╭─────────────────────┬───────┬─────────────┬───────────────┬─────────────────╮      
│ dataset             │ codec │ compress_dt │ decompress_dt │ compressed_size │
├─────────────────────┼───────┼─────────────┼───────────────┼─────────────────┤
│ i32_interl0         │ pco   │  60.84105ms │     3.95345ms │          890794 │
│ i64_interl0         │ pco   │  67.02285ms │     4.90655ms │          891168 │      
│ i32_interl1         │ pco   │   66.9435ms │       4.099ms │          541198 │      
│ i64_interl1         │ pco   │   70.1553ms │     5.12095ms │          541270 │      
│ i32_interl_scrambl1 │ pco   │  80.34415ms │      4.2488ms │         1106568 │      
│ i64_interl_scrambl1 │ pco   │  69.42205ms │     5.10795ms │         1106654 │      
│ <sum>               │ pco   │  414.7289ms │     27.4367ms │         5077652 │      
│ <sum>               │ <sum> │  414.7289ms │     27.4367ms │         5077652 │      
╰─────────────────────┴───────┴─────────────┴───────────────┴─────────────────╯    

Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz:
main:
╭─────────────────────┬───────┬──────────────┬───────────────┬─────────────────╮
│ dataset             │ codec │  compress_dt │ decompress_dt │ compressed_size │
├─────────────────────┼───────┼──────────────┼───────────────┼─────────────────┤
│ i32_interl0         │ pco   │  92.537413ms │    6.549404ms │          890794 │
│ i64_interl0         │ pco   │  88.148776ms │    6.630989ms │          891168 │
│ i32_interl1         │ pco   │  82.484466ms │    6.015548ms │          541198 │
│ i64_interl1         │ pco   │  88.400502ms │    6.628358ms │          541270 │
│ i32_interl_scrambl1 │ pco   │  89.182903ms │    6.616342ms │         1106568 │
│ i64_interl_scrambl1 │ pco   │  95.131184ms │    7.270969ms │         1106654 │
│ <sum>               │ pco   │ 535.885244ms │    39.71161ms │         5077652 │
│ <sum>               │ <sum> │ 535.885244ms │    39.71161ms │         5077652 │
╰─────────────────────┴───────┴──────────────┴───────────────┴─────────────────╯
no-argmax:
╭─────────────────────┬───────┬──────────────┬───────────────┬─────────────────╮
│ dataset             │ codec │  compress_dt │ decompress_dt │ compressed_size │
├─────────────────────┼───────┼──────────────┼───────────────┼─────────────────┤
│ i32_interl0         │ pco   │  96.517644ms │     7.18903ms │          890794 │
│ i64_interl0         │ pco   │  82.453743ms │    7.097635ms │          891168 │
│ i32_interl1         │ pco   │  87.260784ms │    6.602727ms │          541198 │
│ i64_interl1         │ pco   │  81.930468ms │    7.055602ms │          541270 │
│ i32_interl_scrambl1 │ pco   │  94.036032ms │    7.155916ms │         1106568 │
│ i64_interl_scrambl1 │ pco   │  87.105378ms │    7.852009ms │         1106654 │
│ <sum>               │ pco   │ 529.304049ms │   42.952919ms │         5077652 │
│ <sum>               │ <sum> │ 529.304049ms │   42.952919ms │         5077652 │
╰─────────────────────┴───────┴──────────────┴───────────────┴─────────────────╯
vectorized-lookback-goodness:
╭─────────────────────┬───────┬──────────────┬───────────────┬─────────────────╮
│ dataset             │ codec │  compress_dt │ decompress_dt │ compressed_size │
├─────────────────────┼───────┼──────────────┼───────────────┼─────────────────┤
│ i32_interl0         │ pco   │  94.065806ms │    6.551866ms │          890794 │
│ i64_interl0         │ pco   │  90.745982ms │    6.652709ms │          891168 │
│ i32_interl1         │ pco   │  89.614793ms │     5.97645ms │          541198 │
│ i64_interl1         │ pco   │   94.45275ms │    6.601613ms │          541270 │
│ i32_interl_scrambl1 │ pco   │ 122.174215ms │    6.606691ms │         1106568 │
│ i64_interl_scrambl1 │ pco   │ 124.820737ms │    7.250678ms │         1106654 │
│ <sum>               │ pco   │ 615.874283ms │   39.640007ms │         5077652 │
│ <sum>               │ <sum> │ 615.874283ms │   39.640007ms │         5077652 │
╰─────────────────────┴───────┴──────────────┴───────────────┴─────────────────╯